### PR TITLE
Update chunkSize default in routeV3 API for funding sources processing

### DIFF
--- a/app/api/admin/funding-sources/[id]/process/routeV3.js
+++ b/app/api/admin/funding-sources/[id]/process/routeV3.js
@@ -16,7 +16,7 @@ export async function POST(request, { params }) {
 		// Parse request body for options
 		const body = await request.json().catch(() => ({}));
 		const options = {
-			chunkSize: body.chunkSize || 5,
+			chunkSize: body.chunkSize || 20,
 			forceFullProcessing: body.forceFullProcessing || false,
 			...body
 		};


### PR DESCRIPTION
- Changed the default value of chunkSize from 5 to 20 in the routeV3 API, improving data processing efficiency and allowing for larger batches during job processing.