### PR TITLE
feat: add admin role infrastructure via Supabase app_metadata

### DIFF
--- a/contexts/AuthContext.js
+++ b/contexts/AuthContext.js
@@ -112,6 +112,12 @@ export function AuthProvider({ children }) {
 		signInWithMicrosoft,
 		signOut,
 		isAuthenticated: !!user,
+		// Admin role derived from Supabase app_metadata (set via service_role only)
+		// In dev mode, NEXT_PUBLIC_DEV_ADMIN=true simulates admin without real metadata
+		isAdmin:
+			(process.env.NODE_ENV === 'development' &&
+				process.env.NEXT_PUBLIC_DEV_ADMIN === 'true') ||
+			user?.app_metadata?.role === 'admin',
 		// Helper to get user display name from Microsoft user metadata
 		displayName:
 			user?.user_metadata?.full_name ||

--- a/scripts/admin-role.sql
+++ b/scripts/admin-role.sql
@@ -1,0 +1,59 @@
+-- ============================================================
+-- Admin Role Management via Supabase app_metadata
+-- ============================================================
+--
+-- Supabase stores role in auth.users.raw_app_meta_data (JSONB).
+-- The JS SDK exposes it as user.app_metadata.role.
+-- Only service_role operations can modify app_metadata — users
+-- cannot self-assign roles.
+--
+-- IMPORTANT: After granting or revoking admin, the user must
+-- sign out and back in (or wait for JWT refresh, ~60 min) for
+-- the change to take effect in their browser session.
+--
+-- Run via:
+--   psql "$PROD_CLAUDE_URL" -f scripts/admin-role.sql
+--   psql "$STAGING_CLAUDE_URL" -f scripts/admin-role.sql
+--   Or: Supabase Dashboard > SQL Editor
+-- ============================================================
+
+-- -----------------------------------------------
+-- GRANT ADMIN
+-- Replace 'user@example.com' with the target email
+-- -----------------------------------------------
+UPDATE auth.users
+SET raw_app_meta_data = raw_app_meta_data || '{"role": "admin"}'::jsonb
+WHERE email = 'user@example.com';
+
+-- -----------------------------------------------
+-- VERIFY
+-- -----------------------------------------------
+SELECT id, email, raw_app_meta_data->>'role' AS role
+FROM auth.users
+WHERE email = 'user@example.com';
+
+-- -----------------------------------------------
+-- REVOKE ADMIN (uncomment to use)
+-- -----------------------------------------------
+-- UPDATE auth.users
+-- SET raw_app_meta_data = raw_app_meta_data - 'role'
+-- WHERE email = 'user@example.com';
+
+-- ============================================================
+-- Alternative: Supabase Admin API (cURL)
+-- ============================================================
+--
+-- # Grant admin
+-- curl -X PUT \
+--   "${SUPABASE_URL}/auth/v1/admin/users/${USER_ID}" \
+--   -H "Authorization: Bearer ${SERVICE_ROLE_KEY}" \
+--   -H "Content-Type: application/json" \
+--   -d '{"app_metadata": {"role": "admin"}}'
+--
+-- # Revoke admin
+-- curl -X PUT \
+--   "${SUPABASE_URL}/auth/v1/admin/users/${USER_ID}" \
+--   -H "Authorization: Bearer ${SERVICE_ROLE_KEY}" \
+--   -H "Content-Type: application/json" \
+--   -d '{"app_metadata": {"role": null}}'
+-- ============================================================

--- a/tests/critical/auth/isAdmin.test.js
+++ b/tests/critical/auth/isAdmin.test.js
@@ -1,0 +1,119 @@
+import { describe, test, expect } from 'vitest';
+
+/**
+ * Inline function replicating isAdmin logic from contexts/AuthContext.js.
+ * Must be kept in sync with the production derivation.
+ */
+function getIsAdmin(user, isDev = false, devAdminEnv = '') {
+	if (isDev && devAdminEnv === 'true') {
+		return true;
+	}
+	return user?.app_metadata?.role === 'admin';
+}
+
+/**
+ * Inline function replicating role extraction from:
+ * - utils/supabase/api.js requireRole()
+ * - utils/supabase/middleware.js enforceRBAC()
+ * Must be kept in sync with both files.
+ */
+function extractUserRole(user) {
+	return (
+		user?.app_metadata?.role ||
+		user?.user_metadata?.role ||
+		user?.role ||
+		null
+	);
+}
+
+describe('isAdmin derivation', () => {
+	describe('production mode (isDev=false)', () => {
+		test('returns true when app_metadata.role is admin', () => {
+			const user = { app_metadata: { role: 'admin' } };
+			expect(getIsAdmin(user, false)).toBe(true);
+		});
+
+		test('returns false when app_metadata.role is missing', () => {
+			const user = { app_metadata: {} };
+			expect(getIsAdmin(user, false)).toBe(false);
+		});
+
+		test('returns false when app_metadata is missing entirely', () => {
+			const user = {};
+			expect(getIsAdmin(user, false)).toBe(false);
+		});
+
+		test('returns false when user is null', () => {
+			expect(getIsAdmin(null, false)).toBe(false);
+		});
+
+		test('returns false when user is undefined', () => {
+			expect(getIsAdmin(undefined, false)).toBe(false);
+		});
+
+		test('returns false for non-admin role', () => {
+			const user = { app_metadata: { role: 'viewer' } };
+			expect(getIsAdmin(user, false)).toBe(false);
+		});
+
+		test('ignores NEXT_PUBLIC_DEV_ADMIN in production', () => {
+			const user = { app_metadata: {} };
+			expect(getIsAdmin(user, false, 'true')).toBe(false);
+		});
+	});
+
+	describe('development mode (isDev=true)', () => {
+		test('returns true when DEV_ADMIN is "true" regardless of user', () => {
+			expect(getIsAdmin(null, true, 'true')).toBe(true);
+			expect(getIsAdmin({}, true, 'true')).toBe(true);
+			expect(getIsAdmin({ app_metadata: {} }, true, 'true')).toBe(true);
+		});
+
+		test('falls back to app_metadata when DEV_ADMIN is not "true"', () => {
+			const adminUser = { app_metadata: { role: 'admin' } };
+			const normalUser = { app_metadata: {} };
+			expect(getIsAdmin(adminUser, true, 'false')).toBe(true);
+			expect(getIsAdmin(normalUser, true, 'false')).toBe(false);
+			expect(getIsAdmin(normalUser, true, '')).toBe(false);
+			expect(getIsAdmin(normalUser, true, undefined)).toBe(false);
+		});
+	});
+});
+
+describe('extractUserRole (requireRole / enforceRBAC)', () => {
+	test('prefers app_metadata.role', () => {
+		const user = {
+			app_metadata: { role: 'admin' },
+			user_metadata: { role: 'viewer' },
+			role: 'anon',
+		};
+		expect(extractUserRole(user)).toBe('admin');
+	});
+
+	test('falls back to user_metadata.role when app_metadata has no role', () => {
+		const user = {
+			app_metadata: {},
+			user_metadata: { role: 'viewer' },
+			role: 'anon',
+		};
+		expect(extractUserRole(user)).toBe('viewer');
+	});
+
+	test('falls back to user.role when no metadata has role', () => {
+		const user = {
+			app_metadata: {},
+			user_metadata: {},
+			role: 'authenticated',
+		};
+		expect(extractUserRole(user)).toBe('authenticated');
+	});
+
+	test('returns null when no role anywhere', () => {
+		const user = { app_metadata: {}, user_metadata: {} };
+		expect(extractUserRole(user)).toBeNull();
+	});
+
+	test('returns null for null user', () => {
+		expect(extractUserRole(null)).toBeNull();
+	});
+});

--- a/utils/supabase/api.js
+++ b/utils/supabase/api.js
@@ -190,8 +190,8 @@ export async function requireRole(request, allowedRoles) {
     return { authorized: false, user: null, supabase, response };
   }
   
-  // Check user role (assumes role is stored in user metadata or custom claims)
-  const userRole = user.user_metadata?.role || user.role;
+  // Check user role — app_metadata is the secure source (server-only settable)
+  const userRole = user.app_metadata?.role || user.user_metadata?.role || user.role;
   const authorized = allowedRoles.includes(userRole);
   
   return { authorized, user, supabase, response };

--- a/utils/supabase/middleware.js
+++ b/utils/supabase/middleware.js
@@ -214,8 +214,8 @@ export async function enforceRBAC(request, roleConfig, unauthorizedPath = '/unau
       return NextResponse.redirect(new URL('/login', request.url));
     }
     
-    // Check user role (assumes role is stored in user metadata or custom claims)
-    const userRole = user.user_metadata?.role || user.role;
+    // Check user role — app_metadata is the secure source (server-only settable)
+    const userRole = user.app_metadata?.role || user.user_metadata?.role || user.role;
     
     if (!requiredRoles.includes(userRole)) {
       return NextResponse.redirect(new URL(unauthorizedPath, request.url));


### PR DESCRIPTION
## Summary
- Add `isAdmin` boolean to AuthContext derived from `user.app_metadata.role`
- Update `requireRole` and `enforceRBAC` helpers to check `app_metadata` first (secure, server-only settable)
- Add `NEXT_PUBLIC_DEV_ADMIN` env var for easy admin toggle in local dev
- Add SQL runbook script for granting/revoking admin role
- 14 component tests covering isAdmin derivation + role extraction logic

Relates to #30

## Test plan
- [x] `npm run test:critical` — 46 files, 1141 tests passed (includes new isAdmin tests)
- [x] `npm run test:api` — 13 files, 227 tests passed
- [x] `npm run build` — passes clean
- [x] Code review — no issues found
- [x] Inline function drift check — no drift between test and production logic