### PR TITLE
feat: gate /admin/* routes to admin-only access

### DIFF
--- a/app/admin/layout.js
+++ b/app/admin/layout.js
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/contexts/AuthContext';
+
+export default function AdminLayout({ children }) {
+	const { isAdmin, loading } = useAuth();
+	const router = useRouter();
+
+	useEffect(() => {
+		if (!loading && !isAdmin) {
+			router.push('/');
+		}
+	}, [isAdmin, loading, router]);
+
+	if (loading) {
+		return (
+			<div className='flex items-center justify-center min-h-[50vh]'>
+				<div className='animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600' />
+			</div>
+		);
+	}
+
+	if (!isAdmin) {
+		return null;
+	}
+
+	return children;
+}

--- a/components/layout/main-layout.jsx
+++ b/components/layout/main-layout.jsx
@@ -11,8 +11,9 @@ import {
 	NavigationMenuTrigger,
 } from '@/components/ui/navigation-menu';
 import { cn } from '@/lib/utils';
-import { HelpCircle, Moon, Sun } from 'lucide-react';
+import { HelpCircle, Moon, Sun, Shield } from 'lucide-react';
 import { useTheme } from '@/components/theme-provider';
+import { useAuth } from '@/contexts/AuthContext';
 import { UserMenu } from '@/components/auth/UserMenu';
 import HelpModal from '@/components/help/HelpModal';
 
@@ -106,6 +107,8 @@ const MainLayout = ({ children }) => {
 };
 
 const MainNav = () => {
+	const { isAdmin } = useAuth();
+
 	// Memoize common navigation class styles
 	const navLinkClasses = cn(
 		'inline-flex h-9 md:h-10 items-center justify-center rounded-md px-3 md:px-4 py-2 text-sm font-medium transition-all duration-200',
@@ -168,6 +171,26 @@ const MainNav = () => {
 						Timeline
 					</ClientSideActiveLink>
 				</NavigationMenuItem>
+				{isAdmin && (
+					<NavigationMenuItem>
+						<NavigationMenuTrigger className={cn(navLinkClasses, 'group')}>
+							<Shield size={14} className='mr-1' />
+							Admin
+						</NavigationMenuTrigger>
+						<NavigationMenuContent>
+							<ul className='grid w-[400px] gap-4 p-6 md:w-[500px] md:grid-cols-2 lg:w-[600px] animate-in fade-in-50 zoom-in-95 duration-200'>
+								{adminNavItems.map((item) => (
+									<ListItem
+										key={item.title}
+										title={item.title}
+										href={item.href}>
+										{item.description}
+									</ListItem>
+								))}
+							</ul>
+						</NavigationMenuContent>
+					</NavigationMenuItem>
+				)}
 			</NavigationMenuList>
 		</NavigationMenu>
 	);
@@ -216,6 +239,29 @@ const fundingNavItems = [
 		title: 'Map View',
 		href: '/map',
 		description: 'Visualize funding opportunities by geographic region.',
+	},
+];
+
+const adminNavItems = [
+	{
+		title: 'Review Queue',
+		href: '/admin/review',
+		description: 'Review and approve pending funding opportunities.',
+	},
+	{
+		title: 'Funding Sources',
+		href: '/admin/funding-sources',
+		description: 'Manage API sources and processing configurations.',
+	},
+	{
+		title: 'Verify Data',
+		href: '/admin/funding/verify',
+		description: 'Verify funding data integrity and accuracy.',
+	},
+	{
+		title: 'Debug',
+		href: '/admin/debug',
+		description: 'Debug tools and system diagnostics.',
 	},
 ];
 

--- a/middleware.js
+++ b/middleware.js
@@ -64,6 +64,14 @@ export async function middleware(request) {
 		return NextResponse.redirect(loginUrl);
 	}
 
+	// Admin routes require admin role
+	if (request.nextUrl.pathname.startsWith('/admin')) {
+		const userRole = user.app_metadata?.role;
+		if (userRole !== 'admin') {
+			return NextResponse.redirect(new URL('/', request.url));
+		}
+	}
+
 	// User is authenticated - allow access
 	return supabaseResponse;
 }

--- a/tests/critical/auth/adminRouteGating.test.js
+++ b/tests/critical/auth/adminRouteGating.test.js
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'vitest';
+
+/**
+ * Inline function replicating middleware admin route gating logic from middleware.js.
+ * Returns true if the request should be blocked (non-admin accessing /admin/* path).
+ * Must be kept in sync with the middleware admin check.
+ */
+function shouldBlockAdminRoute(pathname, userRole) {
+	if (!pathname.startsWith('/admin')) {
+		return false;
+	}
+	return userRole !== 'admin';
+}
+
+/**
+ * Inline function replicating nav visibility logic from components/layout/main-layout.jsx.
+ * Returns true if admin nav items should be shown.
+ */
+function shouldShowAdminNav(isAdmin) {
+	return !!isAdmin;
+}
+
+describe('admin route gating (middleware)', () => {
+	describe('admin paths', () => {
+		test('blocks non-admin on /admin', () => {
+			expect(shouldBlockAdminRoute('/admin', undefined)).toBe(true);
+			expect(shouldBlockAdminRoute('/admin', null)).toBe(true);
+			expect(shouldBlockAdminRoute('/admin', 'viewer')).toBe(true);
+		});
+
+		test('blocks non-admin on /admin/review', () => {
+			expect(shouldBlockAdminRoute('/admin/review', 'viewer')).toBe(true);
+		});
+
+		test('blocks non-admin on nested admin paths', () => {
+			expect(shouldBlockAdminRoute('/admin/funding-sources', undefined)).toBe(true);
+			expect(shouldBlockAdminRoute('/admin/funding-sources/123', 'viewer')).toBe(true);
+			expect(shouldBlockAdminRoute('/admin/funding/verify', null)).toBe(true);
+			expect(shouldBlockAdminRoute('/admin/debug', 'authenticated')).toBe(true);
+		});
+
+		test('allows admin on all admin paths', () => {
+			expect(shouldBlockAdminRoute('/admin', 'admin')).toBe(false);
+			expect(shouldBlockAdminRoute('/admin/review', 'admin')).toBe(false);
+			expect(shouldBlockAdminRoute('/admin/funding-sources', 'admin')).toBe(false);
+			expect(shouldBlockAdminRoute('/admin/funding-sources/123/edit', 'admin')).toBe(false);
+			expect(shouldBlockAdminRoute('/admin/debug', 'admin')).toBe(false);
+		});
+	});
+
+	describe('non-admin paths are unaffected', () => {
+		test('does not block any role on regular paths', () => {
+			expect(shouldBlockAdminRoute('/', undefined)).toBe(false);
+			expect(shouldBlockAdminRoute('/dashboard', 'viewer')).toBe(false);
+			expect(shouldBlockAdminRoute('/funding/opportunities', null)).toBe(false);
+			expect(shouldBlockAdminRoute('/clients', 'admin')).toBe(false);
+			expect(shouldBlockAdminRoute('/map', 'authenticated')).toBe(false);
+		});
+
+		test('does not block non-admin paths with "admin" elsewhere in URL', () => {
+			expect(shouldBlockAdminRoute('/settings/admin-panel', undefined)).toBe(false);
+			expect(shouldBlockAdminRoute('/users/admin-config', 'viewer')).toBe(false);
+		});
+	});
+});
+
+describe('admin nav visibility', () => {
+	test('shows admin nav for admin users', () => {
+		expect(shouldShowAdminNav(true)).toBe(true);
+	});
+
+	test('hides admin nav for non-admin users', () => {
+		expect(shouldShowAdminNav(false)).toBe(false);
+	});
+
+	test('hides admin nav for undefined/null', () => {
+		expect(shouldShowAdminNav(undefined)).toBe(false);
+		expect(shouldShowAdminNav(null)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- Middleware redirects non-admin users from `/admin/*` routes to `/`
- Client-side admin layout guard catches SPA navigation
- Admin nav menu (Review Queue, Funding Sources, Verify Data, Debug) only visible to admin users
- Inline-function tests for route gating and nav visibility

Relates to #31