### PR TITLE
feat: switch frontend to read from persisted client_matches

### DIFF
--- a/app/api/client-matching/route.js
+++ b/app/api/client-matching/route.js
@@ -1,159 +1,49 @@
 /**
  * Client-Opportunity Matching API
  *
- * Matches clients from the database against real opportunities
- * Returns match scores based on location, applicant type, project needs, and activities
+ * Reads pre-computed matches from the client_matches table (populated by
+ * the background match computation job). JOINs funding_opportunities for
+ * full opportunity details.
  *
- * Location matching uses coverage_area_ids for precise geographic matching:
- * - Utility-level precision (e.g., PG&E vs SCE)
- * - County-level precision (e.g., Marin County)
- * - State-level matching
- * - National opportunities match all clients
+ * Much faster than the previous approach which recomputed matches from
+ * scratch on every request using O(n*m) evaluateMatch() calls.
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
-import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
   process.env.SUPABASE_SECRET_KEY
 );
 
+/**
+ * Transform a raw client_matches row (with joined opportunity) into the
+ * response shape the frontend expects.
+ */
+function transformMatch(row) {
+  const opp = row.opportunity;
+  return {
+    ...opp,
+    source_type: opp.funding_sources?.type || null,
+    funding_sources: undefined,
+    score: row.score,
+    matchDetails: row.match_details,
+    is_new: row.is_new,
+    first_matched_at: row.first_matched_at
+  };
+}
+
 export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
     const clientId = searchParams.get('clientId');
 
-    console.log(`[ClientMatching] Starting matching process${clientId ? ` for client: ${clientId}` : ' for all clients'}`);
-
-    // Get clients from database
-    let clientQuery = supabase.from('clients').select('*');
+    console.log(`[ClientMatching] Reading persisted matches${clientId ? ` for client: ${clientId}` : ' for all clients'}`);
 
     if (clientId) {
-      clientQuery = clientQuery.eq('id', clientId);
+      return handleSingleClient(clientId);
     }
-
-    const { data: clientsToProcess, error: clientError } = await clientQuery;
-
-    if (clientError) {
-      console.error('[ClientMatching] Error fetching clients:', clientError);
-      return Response.json({ error: 'Failed to fetch clients' }, { status: 500 });
-    }
-
-    if (!clientsToProcess || clientsToProcess.length === 0) {
-      return Response.json({ error: 'Client not found' }, { status: 404 });
-    }
-
-    // Get all open opportunities with source type from funding_sources (exclude closed)
-    const { data: rawOpportunities, error } = await supabase
-      .from('funding_opportunities')
-      .select(`
-        id, title, eligible_locations, eligible_applicants,
-        eligible_project_types, eligible_activities, is_national,
-        minimum_award, maximum_award, total_funding_available,
-        close_date, agency_name, categories, relevance_score,
-        status, created_at, program_overview, program_insights,
-        funding_sources(type)
-      `)
-      .neq('status', 'closed')
-      .or('promotion_status.is.null,promotion_status.eq.promoted');
-
-    if (error) {
-      console.error('[ClientMatching] Database error:', error);
-      return Response.json({ error: 'Failed to fetch opportunities' }, { status: 500 });
-    }
-
-    // Flatten funding_sources.type to source_type on each opportunity
-    const opportunities = (rawOpportunities || []).map(opp => ({
-      ...opp,
-      source_type: opp.funding_sources?.type || null,
-      funding_sources: undefined // Remove nested object
-    }));
-
-    // Get opportunity coverage areas separately (since we need to join)
-    const { data: opportunityCoverageAreas, error: coverageError } = await supabase
-      .from('opportunity_coverage_areas')
-      .select('opportunity_id, coverage_area_id');
-
-    if (coverageError) {
-      console.error('[ClientMatching] Error fetching coverage areas:', coverageError);
-      return Response.json({ error: 'Failed to fetch opportunity coverage areas' }, { status: 500 });
-    }
-
-    // Build lookup map: opportunityId -> coverageAreaIds[]
-    const opportunityCoverageMap = {};
-    for (const link of opportunityCoverageAreas || []) {
-      if (!opportunityCoverageMap[link.opportunity_id]) {
-        opportunityCoverageMap[link.opportunity_id] = [];
-      }
-      opportunityCoverageMap[link.opportunity_id].push(link.coverage_area_id);
-    }
-
-    // Attach coverage area IDs to each opportunity
-    for (const opp of opportunities) {
-      opp.coverage_area_ids = opportunityCoverageMap[opp.id] || [];
-    }
-
-    console.log(`[ClientMatching] Found ${opportunities.length} opportunities to match against`);
-
-    // Batch-fetch all hidden matches in a single query (eliminates N+1 pattern)
-    const { data: allHiddenMatches, error: hiddenError } = await supabase
-      .from('hidden_matches')
-      .select('client_id, opportunity_id');
-
-    if (hiddenError) {
-      console.error('[ClientMatching] Error fetching hidden matches:', hiddenError);
-    }
-
-    const hiddenMap = new Map();
-    for (const h of allHiddenMatches || []) {
-      if (!hiddenMap.has(h.client_id)) hiddenMap.set(h.client_id, new Set());
-      hiddenMap.get(h.client_id).add(h.opportunity_id);
-    }
-
-    // Calculate matches for each client
-    const results = {};
-
-    for (const client of clientsToProcess) {
-      console.log(`[ClientMatching] Processing client: ${client.name}`);
-      console.log(`[ClientMatching] Client details:`, {
-        type: client.type,
-        project_needs: client.project_needs,
-        coverage_area_count: client.coverage_area_ids?.length || 0,
-        city: client.city,
-        state_code: client.state_code
-      });
-
-      const hiddenOpportunityIds = hiddenMap.get(client.id) || new Set();
-      const hiddenCount = hiddenOpportunityIds.size;
-
-      // Filter out hidden opportunities before matching
-      const visibleOpportunities = opportunities.filter(opp => !hiddenOpportunityIds.has(opp.id));
-
-      if (hiddenCount > 0) {
-        console.log(`[ClientMatching] Filtered out ${hiddenCount} hidden matches for ${client.name}`);
-      }
-
-      const matches = calculateMatches(client, visibleOpportunities);
-
-      results[client.id] = {
-        client,
-        matches: matches.sort((a, b) => b.score - a.score), // Sort by score descending
-        matchCount: matches.length,
-        hiddenCount, // Include hidden count in response
-        topMatches: matches.slice(0, 3) // Top 3 for card display
-      };
-
-      console.log(`[ClientMatching] Found ${matches.length} matches for ${client.name}`);
-    }
-
-    return Response.json({
-      success: true,
-      results: clientId ? results[clientId] : results,
-      timestamp: new Date().toISOString()
-    });
-
+    return handleAllClients();
   } catch (error) {
     console.error('[ClientMatching] API error:', error);
     return Response.json({
@@ -164,26 +54,161 @@ export async function GET(request) {
 }
 
 /**
- * Calculate matches between a client and opportunities
+ * Single-client mode: returns matches for one client.
  */
-function calculateMatches(client, opportunities) {
-  const matches = [];
-  const deps = {
-    hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
-    getExpandedClientTypes
-  };
+async function handleSingleClient(clientId) {
+  // 1. Fetch the client
+  const { data: client, error: clientError } = await supabase
+    .from('clients')
+    .select('*')
+    .eq('id', clientId)
+    .single();
 
-  for (const opportunity of opportunities) {
-    const matchResult = evaluateMatch(client, opportunity, deps);
-
-    if (matchResult.isMatch) {
-      matches.push({
-        ...opportunity,
-        score: matchResult.score,
-        matchDetails: matchResult.details
-      });
-    }
+  if (clientError || !client) {
+    console.error('[ClientMatching] Error fetching client:', clientError);
+    return Response.json({ error: 'Client not found' }, { status: 404 });
   }
 
-  return matches;
+  // 2. Fetch hidden opportunity IDs for this client
+  const { data: hiddenRows, error: hiddenError } = await supabase
+    .from('hidden_matches')
+    .select('opportunity_id')
+    .eq('client_id', clientId)
+    .limit(10000);
+
+  if (hiddenError) {
+    console.error('[ClientMatching] Error fetching hidden matches:', hiddenError);
+  }
+
+  const hiddenIds = new Set((hiddenRows || []).map(h => h.opportunity_id));
+
+  // 3. Query persisted matches with opportunity details
+  const { data: matchRows, error: matchError } = await supabase
+    .from('client_matches')
+    .select(`
+      score, match_details, is_new, first_matched_at,
+      opportunity:funding_opportunities!inner(
+        *, funding_sources(type)
+      )
+    `)
+    .eq('client_id', clientId)
+    .eq('is_stale', false)
+    .limit(10000);
+
+  if (matchError) {
+    console.error('[ClientMatching] Error fetching matches:', matchError);
+    return Response.json({ error: 'Failed to fetch matches' }, { status: 500 });
+  }
+
+  // 4. Filter hidden and transform
+  const matches = (matchRows || [])
+    .filter(row => !hiddenIds.has(row.opportunity.id))
+    .map(transformMatch)
+    .sort((a, b) => b.score - a.score);
+
+  const result = {
+    client,
+    matches,
+    matchCount: matches.length,
+    hiddenCount: hiddenIds.size,
+    topMatches: matches.slice(0, 3)
+  };
+
+  console.log(`[ClientMatching] Found ${matches.length} matches for ${client.name}`);
+
+  return Response.json({
+    success: true,
+    results: result,
+    timestamp: new Date().toISOString()
+  });
+}
+
+/**
+ * All-clients mode: returns matches grouped by client.
+ */
+async function handleAllClients() {
+  // 1. Fetch all clients
+  const { data: clients, error: clientError } = await supabase
+    .from('clients')
+    .select('*');
+
+  if (clientError) {
+    console.error('[ClientMatching] Error fetching clients:', clientError);
+    return Response.json({ error: 'Failed to fetch clients' }, { status: 500 });
+  }
+
+  if (!clients || clients.length === 0) {
+    return Response.json({ error: 'No clients found' }, { status: 404 });
+  }
+
+  // 2. Fetch all non-stale matches with opportunity details
+  const { data: matchRows, error: matchError } = await supabase
+    .from('client_matches')
+    .select(`
+      client_id, score, match_details, is_new, first_matched_at,
+      opportunity:funding_opportunities!inner(
+        *, funding_sources(type)
+      )
+    `)
+    .eq('is_stale', false)
+    .limit(10000);
+
+  if (matchError) {
+    console.error('[ClientMatching] Error fetching matches:', matchError);
+    return Response.json({ error: 'Failed to fetch matches' }, { status: 500 });
+  }
+
+  // 3. Batch-fetch all hidden matches
+  const { data: allHiddenMatches, error: hiddenError } = await supabase
+    .from('hidden_matches')
+    .select('client_id, opportunity_id')
+    .limit(10000);
+
+  if (hiddenError) {
+    console.error('[ClientMatching] Error fetching hidden matches:', hiddenError);
+  }
+
+  const hiddenMap = new Map();
+  for (const h of allHiddenMatches || []) {
+    if (!hiddenMap.has(h.client_id)) hiddenMap.set(h.client_id, new Set());
+    hiddenMap.get(h.client_id).add(h.opportunity_id);
+  }
+
+  // 4. Group matches by client, filter hidden, transform
+  const matchesByClient = new Map();
+  for (const row of matchRows || []) {
+    const cid = row.client_id;
+    const hiddenIds = hiddenMap.get(cid);
+    if (hiddenIds && hiddenIds.has(row.opportunity.id)) continue;
+
+    if (!matchesByClient.has(cid)) matchesByClient.set(cid, []);
+    matchesByClient.get(cid).push(transformMatch(row));
+  }
+
+  // 5. Build results keyed by client ID
+  const results = {};
+
+  for (const client of clients) {
+    const clientMatches = matchesByClient.get(client.id) || [];
+    clientMatches.sort((a, b) => b.score - a.score);
+
+    const hiddenIds = hiddenMap.get(client.id);
+    const hiddenCount = hiddenIds ? hiddenIds.size : 0;
+
+    results[client.id] = {
+      client,
+      matches: clientMatches,
+      matchCount: clientMatches.length,
+      hiddenCount,
+      topMatches: clientMatches.slice(0, 3)
+    };
+  }
+
+  console.log(`[ClientMatching] Returned matches for ${clients.length} clients`);
+
+  return Response.json({
+    success: true,
+    results,
+    timestamp: new Date().toISOString()
+  });
 }

--- a/app/api/client-matching/summary/route.js
+++ b/app/api/client-matching/summary/route.js
@@ -2,14 +2,14 @@
  * Client Matching Summary API
  *
  * Returns client matching statistics for dashboard display:
- * - clientsWithMatches: number of clients that have at least 1 match
- * - totalMatches: sum of all matches across all clients
+ * - clientsWithMatches: number of clients that have at least 1 visible match
+ * - totalMatches: sum of all visible matches across all clients
  * - totalClients: total number of clients in system
+ *
+ * Reads from persisted client_matches table instead of recomputing.
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
-import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
 	process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -36,91 +36,73 @@ export async function GET() {
 			});
 		}
 
-		console.log('[ClientMatchingSummary] Calculating match statistics');
+		console.log('[ClientMatchingSummary] Calculating match statistics from client_matches');
 
-		// Get all clients from database
-		const { data: clients, error: clientError } = await supabase
+		// 1. Count total clients
+		const { count: totalClients, error: clientError } = await supabase
 			.from('clients')
-			.select('*');
+			.select('*', { count: 'exact', head: true });
 
 		if (clientError) {
-			console.error('[ClientMatchingSummary] Error fetching clients:', clientError);
+			console.error('[ClientMatchingSummary] Error counting clients:', clientError);
 			return Response.json(
-				{ success: false, error: 'Failed to fetch clients' },
+				{ success: false, error: 'Failed to count clients' },
 				{ status: 500 }
 			);
 		}
 
-		const totalClients = clients?.length || 0;
+		// 2. Fetch all non-stale match pairs
+		const { data: matchRows, error: matchError } = await supabase
+			.from('client_matches')
+			.select('client_id, opportunity_id')
+			.eq('is_stale', false)
+			.limit(10000);
 
-		// Get all open opportunities
-		const { data: rawOpportunities, error: oppError } = await supabase
-			.from('funding_opportunities')
-			.select(
-				`
-				id, title, eligible_locations, eligible_applicants,
-				eligible_project_types, eligible_activities, is_national,
-				status
-			`
-			)
-			.neq('status', 'closed')
-			.or('promotion_status.is.null,promotion_status.eq.promoted');
-
-		if (oppError) {
-			console.error('[ClientMatchingSummary] Error fetching opportunities:', oppError);
+		if (matchError) {
+			console.error('[ClientMatchingSummary] Error fetching matches:', matchError);
 			return Response.json(
-				{ success: false, error: 'Failed to fetch opportunities' },
+				{ success: false, error: 'Failed to fetch matches' },
 				{ status: 500 }
 			);
 		}
 
-		// Get opportunity coverage areas
-		const { data: opportunityCoverageAreas, error: coverageError } = await supabase
-			.from('opportunity_coverage_areas')
-			.select('opportunity_id, coverage_area_id');
+		// 3. Fetch hidden matches to exclude
+		const { data: hiddenRows, error: hiddenError } = await supabase
+			.from('hidden_matches')
+			.select('client_id, opportunity_id')
+			.limit(10000);
 
-		if (coverageError) {
-			console.error('[ClientMatchingSummary] Error fetching coverage areas:', coverageError);
+		if (hiddenError) {
+			console.error('[ClientMatchingSummary] Error fetching hidden matches:', hiddenError);
 		}
 
-		// Build coverage map
-		const opportunityCoverageMap = {};
-		for (const link of opportunityCoverageAreas || []) {
-			if (!opportunityCoverageMap[link.opportunity_id]) {
-				opportunityCoverageMap[link.opportunity_id] = [];
-			}
-			opportunityCoverageMap[link.opportunity_id].push(link.coverage_area_id);
-		}
+		const hiddenSet = new Set(
+			(hiddenRows || []).map(h => `${h.client_id}:${h.opportunity_id}`)
+		);
 
-		// Attach coverage areas to opportunities
-		const opportunities = (rawOpportunities || []).map((opp) => ({
-			...opp,
-			coverage_area_ids: opportunityCoverageMap[opp.id] || [],
-		}));
-
-		// Calculate matches for each client
-		let clientsWithMatches = 0;
+		// 4. Filter visible matches and compute stats
+		const clientsWithMatchesSet = new Set();
 		let totalMatches = 0;
 
-		for (const client of clients || []) {
-			const matchCount = countMatches(client, opportunities);
-			if (matchCount > 0) {
-				clientsWithMatches++;
-				totalMatches += matchCount;
-			}
+		for (const row of matchRows || []) {
+			const key = `${row.client_id}:${row.opportunity_id}`;
+			if (hiddenSet.has(key)) continue;
+			clientsWithMatchesSet.add(row.client_id);
+			totalMatches++;
 		}
 
-		// Cache the result
 		const result = {
-			clientsWithMatches,
+			clientsWithMatches: clientsWithMatchesSet.size,
 			totalMatches,
-			totalClients,
+			totalClients: totalClients || 0,
 		};
+
+		// Cache the result
 		cache.data = result;
 		cache.timestamp = now;
 
 		console.log(
-			`[ClientMatchingSummary] ${clientsWithMatches}/${totalClients} clients with matches, ${totalMatches} total`
+			`[ClientMatchingSummary] ${result.clientsWithMatches}/${result.totalClients} clients with matches, ${totalMatches} total`
 		);
 
 		return Response.json({
@@ -140,24 +122,4 @@ export async function GET() {
 			{ status: 500 }
 		);
 	}
-}
-
-/**
- * Count matches between a client and opportunities
- */
-function countMatches(client, opportunities) {
-	let count = 0;
-	const deps = {
-		hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
-		getExpandedClientTypes
-	};
-
-	for (const opportunity of opportunities) {
-		const result = evaluateMatch(client, opportunity, deps);
-		if (result.isMatch) {
-			count++;
-		}
-	}
-
-	return count;
 }

--- a/app/api/client-matching/top-matches/route.js
+++ b/app/api/client-matching/top-matches/route.js
@@ -3,11 +3,11 @@
  *
  * Returns the top 5 clients with their best opportunity matches for dashboard display.
  * Each result includes the client name, their best matching opportunity, and match score.
+ *
+ * Reads from persisted client_matches table instead of recomputing.
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
-import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
 	process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -34,88 +34,81 @@ export async function GET() {
 			});
 		}
 
-		console.log('[TopMatches] Calculating top client matches');
+		console.log('[TopMatches] Reading top client matches from client_matches');
 
-		// Get all clients
-		const { data: clients, error: clientError } = await supabase
-			.from('clients')
-			.select('*');
+		// 1. Fetch all non-stale matches with client and opportunity details
+		const { data: matchRows, error: matchError } = await supabase
+			.from('client_matches')
+			.select(`
+				client_id, score, opportunity_id,
+				client:clients!inner(id, name, type),
+				opportunity:funding_opportunities!inner(id, title, maximum_award)
+			`)
+			.eq('is_stale', false)
+			.limit(10000);
 
-		if (clientError) {
-			console.error('[TopMatches] Error fetching clients:', clientError);
+		if (matchError) {
+			console.error('[TopMatches] Error fetching matches:', matchError);
 			return Response.json(
-				{ success: false, error: 'Failed to fetch clients' },
+				{ success: false, error: 'Failed to fetch matches' },
 				{ status: 500 }
 			);
 		}
 
-		// Get all open opportunities
-		const { data: rawOpportunities, error: oppError } = await supabase
-			.from('funding_opportunities')
-			.select(
-				`
-				id, title, eligible_locations, eligible_applicants,
-				eligible_project_types, eligible_activities, is_national,
-				maximum_award, close_date, status
-			`
-			)
-			.neq('status', 'closed')
-			.or('promotion_status.is.null,promotion_status.eq.promoted');
+		// 2. Fetch hidden matches to exclude
+		const { data: hiddenRows, error: hiddenError } = await supabase
+			.from('hidden_matches')
+			.select('client_id, opportunity_id')
+			.limit(10000);
 
-		if (oppError) {
-			console.error('[TopMatches] Error fetching opportunities:', oppError);
-			return Response.json(
-				{ success: false, error: 'Failed to fetch opportunities' },
-				{ status: 500 }
-			);
+		if (hiddenError) {
+			console.error('[TopMatches] Error fetching hidden matches:', hiddenError);
 		}
 
-		// Get opportunity coverage areas
-		const { data: opportunityCoverageAreas, error: coverageError } = await supabase
-			.from('opportunity_coverage_areas')
-			.select('opportunity_id, coverage_area_id');
+		const hiddenSet = new Set(
+			(hiddenRows || []).map(h => `${h.client_id}:${h.opportunity_id}`)
+		);
 
-		if (coverageError) {
-			console.error('[TopMatches] Error fetching coverage areas:', coverageError);
-		}
+		// 3. Group by client, filter hidden
+		const clientMap = {};
+		for (const row of matchRows || []) {
+			const key = `${row.client_id}:${row.opportunity_id}`;
+			if (hiddenSet.has(key)) continue;
 
-		// Build coverage map
-		const opportunityCoverageMap = {};
-		for (const link of opportunityCoverageAreas || []) {
-			if (!opportunityCoverageMap[link.opportunity_id]) {
-				opportunityCoverageMap[link.opportunity_id] = [];
+			const cid = row.client_id;
+			if (!clientMap[cid]) {
+				clientMap[cid] = {
+					client_id: row.client.id,
+					client_name: row.client.name,
+					client_type: row.client.type,
+					matches: [],
+				};
 			}
-			opportunityCoverageMap[link.opportunity_id].push(link.coverage_area_id);
+			clientMap[cid].matches.push({
+				id: row.opportunity.id,
+				title: row.opportunity.title,
+				score: row.score,
+				maximum_award: row.opportunity.maximum_award,
+			});
 		}
 
-		// Attach coverage areas to opportunities
-		const opportunities = (rawOpportunities || []).map((opp) => ({
-			...opp,
-			coverage_area_ids: opportunityCoverageMap[opp.id] || [],
-		}));
+		// 4. Build top-matches list
+		const clientResults = Object.values(clientMap).map(entry => {
+			entry.matches.sort((a, b) => b.score - a.score);
+			const top = entry.matches[0];
+			return {
+				client_id: entry.client_id,
+				client_name: entry.client_name,
+				client_type: entry.client_type,
+				match_count: entry.matches.length,
+				top_opportunity_id: top.id,
+				top_opportunity_title: top.title,
+				top_opportunity_score: top.score,
+				top_opportunity_amount: top.maximum_award,
+			};
+		});
 
-		// Calculate matches for each client
-		const clientResults = [];
-
-		for (const client of clients || []) {
-			const matches = calculateMatches(client, opportunities);
-			const topMatch = matches[0]; // Best match by score
-
-			if (topMatch) {
-				clientResults.push({
-					client_id: client.id,
-					client_name: client.name,
-					client_type: client.type,
-					match_count: matches.length,
-					top_opportunity_id: topMatch.id,
-					top_opportunity_title: topMatch.title,
-					top_opportunity_score: topMatch.score,
-					top_opportunity_amount: topMatch.maximum_award,
-				});
-			}
-		}
-
-		// Sort by match count (clients with most matches first), then by top score
+		// 5. Sort by match count (desc), then top score (desc), take top 5
 		clientResults.sort((a, b) => {
 			if (b.match_count !== a.match_count) {
 				return b.match_count - a.match_count;
@@ -123,7 +116,6 @@ export async function GET() {
 			return b.top_opportunity_score - a.top_opportunity_score;
 		});
 
-		// Take top 5
 		const topMatches = clientResults.slice(0, 5);
 
 		// Cache the result
@@ -149,29 +141,4 @@ export async function GET() {
 			{ status: 500 }
 		);
 	}
-}
-
-/**
- * Calculate matches between a client and opportunities
- */
-function calculateMatches(client, opportunities) {
-	const matches = [];
-	const deps = {
-		hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
-		getExpandedClientTypes
-	};
-
-	for (const opportunity of opportunities) {
-		const matchResult = evaluateMatch(client, opportunity, deps);
-
-		if (matchResult.isMatch) {
-			matches.push({
-				...opportunity,
-				score: matchResult.score,
-			});
-		}
-	}
-
-	// Sort by score descending
-	return matches.sort((a, b) => b.score - a.score);
 }

--- a/app/api/cron/compute-matches/route.js
+++ b/app/api/cron/compute-matches/route.js
@@ -17,12 +17,18 @@ import {
 } from '../../../../lib/matching/computeMatches.js';
 
 /**
- * Verify the request has a valid Bearer token matching CRON_SECRET.
+ * Verify the request is authorized.
+ * Accepts either:
+ *  1. Bearer token matching CRON_SECRET (Vercel Cron, GitHub Actions, manual triggers)
+ *  2. Dev mode (NODE_ENV !== 'production')
  * Returns null if valid, or a Response if invalid.
  */
 function verifyAuth(request) {
-  const expectedAuth = process.env.CRON_SECRET;
+  // Allow in dev mode
+  if (process.env.NODE_ENV !== 'production') return null;
 
+  // Verify CRON_SECRET — Vercel automatically includes it as Bearer token for cron jobs
+  const expectedAuth = process.env.CRON_SECRET;
   if (!expectedAuth) {
     console.error('[ComputeMatchesCron] CRON_SECRET is not set');
     return Response.json({ error: 'Server misconfigured' }, { status: 500 });

--- a/app/api/export/client-matches-pdf/route.js
+++ b/app/api/export/client-matches-pdf/route.js
@@ -15,7 +15,9 @@ const supabase = createClient(
 /**
  * POST /api/export/client-matches-pdf
  *
- * Server-side PDF generation for larger exports
+ * Server-side PDF generation for larger exports.
+ * Reads from persisted client_matches table instead of making
+ * a nested HTTP call to /api/client-matching.
  *
  * Body: {
  *   clientId: string,
@@ -34,7 +36,7 @@ export async function POST(request) {
       return NextResponse.json({ error: 'Client ID is required' }, { status: 400 });
     }
 
-    // Fetch client data
+    // 1. Fetch client data
     const { data: client, error: clientError } = await supabase
       .from('clients')
       .select('*')
@@ -48,37 +50,46 @@ export async function POST(request) {
       );
     }
 
-    // Fetch matches using the existing matching API logic
-    const matchesResponse = await fetch(
-      `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/client-matching?clientId=${clientId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
+    // 2. Fetch persisted matches with opportunity details
+    const { data: matchRows, error: matchError } = await supabase
+      .from('client_matches')
+      .select(`
+        score, match_details,
+        opportunity:funding_opportunities!inner(*)
+      `)
+      .eq('client_id', clientId)
+      .eq('is_stale', false)
+      .order('score', { ascending: false })
+      .limit(10000);
 
-    if (!matchesResponse.ok) {
+    if (matchError) {
       return NextResponse.json(
         { error: 'Failed to fetch client matches' },
         { status: 500 }
       );
     }
 
-    const matchesData = await matchesResponse.json();
+    // 3. Exclude hidden matches
+    const { data: hiddenRows } = await supabase
+      .from('hidden_matches')
+      .select('opportunity_id')
+      .eq('client_id', clientId)
+      .limit(10000);
 
-    if (!matchesData.success) {
-      return NextResponse.json(
-        { error: matchesData.error || 'Failed to fetch matches' },
-        { status: 500 }
-      );
-    }
+    const hiddenIds = new Set((hiddenRows || []).map(h => h.opportunity_id));
 
-    const matches = matchesData.results?.matches || [];
+    // 4. Transform to shape expected by PDF component
+    const matches = (matchRows || [])
+      .filter(row => !hiddenIds.has(row.opportunity.id))
+      .map(row => ({
+        ...row.opportunity,
+        score: row.score,
+        matchDetails: row.match_details
+      }));
 
-    // Generate PDF
+    // 5. Generate PDF
     const pdfDoc = React.createElement(ClientMatchesPDF, {
-      client: matchesData.results?.client || client,
+      client,
       matches,
       options,
     });

--- a/app/clients/page.jsx
+++ b/app/clients/page.jsx
@@ -634,13 +634,53 @@ function ClientCard({ clientResult, onViewProfile }) {
 	const locationParts = [client.city, client.state_code].filter(Boolean);
 	const location = locationParts.length > 0 ? locationParts.join(', ') : client.address;
 
+	// Find the most recent new match within 7 days
+	const newestNewMatch = useMemo(() => {
+		if (!matches || matches.length === 0) return null;
+		const now = new Date();
+		const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+		let newest = null;
+		for (const m of matches) {
+			if (m.is_new && m.first_matched_at) {
+				const matchDate = new Date(m.first_matched_at);
+				if (now - matchDate <= sevenDaysMs) {
+					if (!newest || matchDate > new Date(newest.first_matched_at)) {
+						newest = m;
+					}
+				}
+			}
+		}
+		return newest;
+	}, [matches]);
+
+	const newMatchLabel = useMemo(() => {
+		if (!newestNewMatch) return null;
+		const today = new Date();
+		const matchDate = new Date(newestNewMatch.first_matched_at);
+		today.setHours(0, 0, 0, 0);
+		matchDate.setHours(0, 0, 0, 0);
+		const daysAgo = Math.round((today - matchDate) / (1000 * 60 * 60 * 24));
+		if (daysAgo === 0) return 'NEW MATCH • Today';
+		if (daysAgo === 1) return 'NEW MATCH • Yesterday';
+		return `NEW MATCH • ${daysAgo} days ago`;
+	}, [newestNewMatch]);
+
 	return (
 		<Card className='overflow-hidden flex flex-col h-full'>
 			{/* Blue stripe at top */}
 			<div className='h-1.5 w-full bg-blue-600' />
 			<CardHeader className='pb-4'>
-				<CardTitle className='text-xl font-bold'>{client.name}</CardTitle>
-				<CardDescription className='text-sm text-muted-foreground'>{location}</CardDescription>
+				<div className='flex items-start justify-between gap-2'>
+					<div>
+						<CardTitle className='text-xl font-bold'>{client.name}</CardTitle>
+						<CardDescription className='text-sm text-muted-foreground'>{location}</CardDescription>
+					</div>
+					{newMatchLabel && (
+						<span className='text-[10px] font-semibold px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 whitespace-nowrap flex-shrink-0'>
+							{newMatchLabel}
+						</span>
+					)}
+				</div>
 			</CardHeader>
 			<CardContent className='px-6 pb-6 flex flex-col flex-1'>
 				<div className='flex-1 space-y-5'>
@@ -664,7 +704,14 @@ function ClientCard({ clientResult, onViewProfile }) {
 									<li
 										key={`${client.name}-${match.id}-${index}`}
 										className='text-sm border-l-2 border-blue-500 pl-3 py-1 hover:bg-blue-50 dark:hover:bg-blue-900/10 transition-colors duration-200 cursor-pointer rounded-r'>
-										<div className='font-medium truncate pr-12'>{match.title}</div>
+										<div className='font-medium truncate pr-12'>
+											{match.is_new && (
+												<span className='text-[10px] font-semibold px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 mr-1.5 inline-block'>
+													NEW
+												</span>
+											)}
+											{match.title}
+										</div>
 										<div className='flex justify-between items-center'>
 											<span className='text-xs text-gray-500 dark:text-gray-400 truncate flex-1 pr-2'>
 												{match.agency_name || 'Unknown Agency'}

--- a/components/opportunities/OpportunityCard.jsx
+++ b/components/opportunities/OpportunityCard.jsx
@@ -200,6 +200,25 @@ const OpportunityCard = ({ opportunity, badgeOverride }) => {
 			  })()
 			: null;
 
+	// Determine if this is a new match (is_new flag set AND matched within last 7 days)
+	const isNewMatch =
+		opportunity.is_new === true &&
+		opportunity.first_matched_at &&
+		(new Date() - new Date(opportunity.first_matched_at)) / (1000 * 60 * 60 * 24) <= 7;
+
+
+
+	const matchedDaysAgo =
+		isNewMatch && opportunity.first_matched_at
+			? (() => {
+					const today = new Date();
+					const matchedDate = new Date(opportunity.first_matched_at);
+					today.setHours(0, 0, 0, 0);
+					matchedDate.setHours(0, 0, 0, 0);
+					return Math.round((today - matchedDate) / (1000 * 60 * 60 * 24));
+			  })()
+			: null;
+
 	// Get relevance score if available - handle both old and new scoring formats
 	const relevanceScore = opportunity.relevance_score ||
 		opportunity.scoring?.finalScore ||
@@ -250,31 +269,39 @@ const OpportunityCard = ({ opportunity, badgeOverride }) => {
 					)}
 				</div>
 
-				{/* NEW badge if applicable - updated to match category pill styling */}
-				{isNew && (
-					<div className='mt-2'>
-						<span className='text-xs font-medium px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'>
-							NEW •{' '}
-							{addedDaysAgo === 0
-								? 'Today'
-								: addedDaysAgo === 1
-								? 'Yesterday'
-								: `${addedDaysAgo} days ago`}
-						</span>
-					</div>
-				)}
-
-				{/* NEWLY UPDATED badge if applicable */}
-				{isNewlyUpdated && (
-					<div className='mt-2'>
-						<span className='text-xs font-medium px-2 py-1 rounded bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300'>
-							UPDATED •{' '}
-							{updatedDaysAgo === 0
-								? 'Today'
-								: updatedDaysAgo === 1
-								? 'Yesterday'
-								: `${updatedDaysAgo} days ago`}
-						</span>
+				{/* Badge row: NEW, UPDATED, and NEW MATCH badges side by side */}
+				{(isNew || isNewlyUpdated || isNewMatch) && (
+					<div className='mt-2 flex flex-wrap gap-1.5'>
+						{isNew && (
+							<span className='text-xs font-medium px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'>
+								NEW •{' '}
+								{addedDaysAgo === 0
+									? 'Today'
+									: addedDaysAgo === 1
+									? 'Yesterday'
+									: `${addedDaysAgo} days ago`}
+							</span>
+						)}
+						{isNewlyUpdated && (
+							<span className='text-xs font-medium px-2 py-1 rounded bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300'>
+								UPDATED •{' '}
+								{updatedDaysAgo === 0
+									? 'Today'
+									: updatedDaysAgo === 1
+									? 'Yesterday'
+									: `${updatedDaysAgo} days ago`}
+							</span>
+						)}
+						{isNewMatch && (
+							<span className='text-xs font-medium px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'>
+								NEW MATCH •{' '}
+								{matchedDaysAgo === 0
+									? 'Today'
+									: matchedDaysAgo === 1
+									? 'Yesterday'
+									: `${matchedDaysAgo} days ago`}
+							</span>
+						)}
 					</div>
 				)}
 			</CardHeader>

--- a/lib/matching/computeMatches.js
+++ b/lib/matching/computeMatches.js
@@ -157,6 +157,15 @@ async function runMatchComputation(supabase, { trigger, scope }) {
       (existingMatches || []).map(m => `${m.client_id}:${m.opportunity_id}`)
     );
 
+    // Identify clients with zero prior matches (first-ever computation).
+    // Their matches are "initial", not "new" — avoids badge noise on new clients.
+    const clientsWithExistingMatches = new Set(
+      (existingMatches || []).map(m => m.client_id)
+    );
+    const firstTimeClientIds = clients
+      .map(c => c.id)
+      .filter(cid => !clientsWithExistingMatches.has(cid));
+
     // 6. UPSERT matches in batches
     // Excludes is_new and first_matched_at from the payload so that:
     // - New rows get DB defaults: is_new=true, first_matched_at=NOW()
@@ -195,6 +204,18 @@ async function runMatchComputation(supabase, { trigger, scope }) {
         } else {
           newCount++;
         }
+      }
+    }
+
+    // 6b. For first-time clients, set is_new=false on all their matches.
+    // When a client is brand new, every match is "initial" — not a delta worth flagging.
+    if (firstTimeClientIds.length > 0) {
+      const { error: clearNewError } = await supabase
+        .from('client_matches')
+        .update({ is_new: false })
+        .in('client_id', firstTimeClientIds);
+      if (clearNewError) {
+        console.warn('[computeMatches] Failed to clear is_new for first-time clients:', clearNewError.message);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "staging:cron": "node scripts/staging-cron.js",
     "staging:cron:once": "node scripts/staging-cron.js --max-empty=1",
     "staging:cron:fast": "node scripts/staging-cron.js --interval=30",
-    "build": "next build",
+    "build": "next build && node scripts/seed-matches.mjs",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run --config tests/vitest.config.js",

--- a/scripts/seed-matches.mjs
+++ b/scripts/seed-matches.mjs
@@ -1,0 +1,63 @@
+/**
+ * One-time build-time match seeder.
+ *
+ * Runs after `next build` to populate client_matches before the
+ * deployment goes live. Skips instantly if matches already exist.
+ *
+ * Remove this script (and the package.json build change) after
+ * first successful deployment to both staging and production.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { computeAllMatches } from '../lib/matching/computeMatches.js';
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SECRET_KEY;
+
+  if (!url || !key) {
+    console.log('[SeedMatches] Missing Supabase credentials, skipping');
+    return;
+  }
+
+  const supabase = createClient(url, key);
+
+  // Fast check: do matches already exist?
+  const { count, error: countError } = await supabase
+    .from('client_matches')
+    .select('id', { count: 'exact', head: true });
+
+  if (countError) {
+    console.warn('[SeedMatches] Could not check client_matches:', countError.message);
+    return;
+  }
+
+  if (count > 0) {
+    console.log(`[SeedMatches] ${count} matches already exist, skipping`);
+    return;
+  }
+
+  // Check if there are clients to match
+  const { count: clientCount, error: clientError } = await supabase
+    .from('clients')
+    .select('id', { count: 'exact', head: true });
+
+  if (clientError) {
+    console.warn('[SeedMatches] Could not check clients:', clientError.message);
+    return;
+  }
+
+  if (!clientCount) {
+    console.log('[SeedMatches] No clients found, skipping');
+    return;
+  }
+
+  console.log(`[SeedMatches] Seeding matches for ${clientCount} clients...`);
+  const stats = await computeAllMatches(supabase);
+  console.log('[SeedMatches] Complete:', JSON.stringify(stats));
+}
+
+main().catch(err => {
+  // Non-fatal: log and exit cleanly so build succeeds
+  console.warn('[SeedMatches] Non-fatal error:', err.message);
+});

--- a/tests/api/client-matching.api.test.js
+++ b/tests/api/client-matching.api.test.js
@@ -13,22 +13,27 @@ import { opportunities } from '../fixtures/opportunities.js';
 
 /**
  * Expected match object shape
+ * Matches the output of transformMatch in app/api/client-matching/route.js:
+ * { ...opp, source_type, score, matchDetails, is_new, first_matched_at }
  */
 const matchSchema = {
-  opportunity_id: 'string',
-  opportunity_title: 'string',
+  id: 'string',
+  title: 'string',
   agency_name: 'string|null',
   score: 'number',
-  matching_criteria: 'object',
+  matchDetails: 'object',
   close_date: 'string|null',
   maximum_award: 'number|null',
   is_national: 'boolean',
+  source_type: 'string|null',
+  is_new: 'boolean',
+  first_matched_at: 'string|null',
 };
 
 /**
- * Expected matching criteria shape
+ * Expected matchDetails shape (camelCase, mapped from match_details in client_matches)
  */
-const matchingCriteriaSchema = {
+const matchDetailsSchema = {
   locationMatch: 'boolean',
   applicantTypeMatch: 'boolean',
   projectNeedsMatch: 'boolean',
@@ -81,11 +86,11 @@ describe('Client Matching API Contract', () => {
   describe('Match Schema', () => {
     test('validates complete match object', () => {
       const match = {
-        opportunity_id: 'opp-123',
-        opportunity_title: 'Clean Energy Grant',
+        id: 'opp-123',
+        title: 'Clean Energy Grant',
         agency_name: 'DOE',
         score: 85,
-        matching_criteria: {
+        matchDetails: {
           locationMatch: true,
           applicantTypeMatch: true,
           projectNeedsMatch: true,
@@ -94,6 +99,9 @@ describe('Client Matching API Contract', () => {
         close_date: '2025-06-30T23:59:59Z',
         maximum_award: 5000000,
         is_national: true,
+        source_type: 'federal',
+        is_new: true,
+        first_matched_at: '2025-06-01T00:00:00Z',
       };
 
       const errors = validateSchema(match, matchSchema);
@@ -102,11 +110,11 @@ describe('Client Matching API Contract', () => {
 
     test('validates match with null optional fields', () => {
       const match = {
-        opportunity_id: 'opp-123',
-        opportunity_title: 'Minimal Grant',
+        id: 'opp-123',
+        title: 'Minimal Grant',
         agency_name: null,
         score: 50,
-        matching_criteria: {
+        matchDetails: {
           locationMatch: true,
           applicantTypeMatch: false,
           projectNeedsMatch: true,
@@ -115,6 +123,9 @@ describe('Client Matching API Contract', () => {
         close_date: null,
         maximum_award: null,
         is_national: false,
+        source_type: null,
+        is_new: false,
+        first_matched_at: null,
       };
 
       const errors = validateSchema(match, matchSchema);
@@ -123,14 +134,17 @@ describe('Client Matching API Contract', () => {
 
     test('score must be a number', () => {
       const match = {
-        opportunity_id: 'opp-123',
-        opportunity_title: 'Grant',
+        id: 'opp-123',
+        title: 'Grant',
         agency_name: null,
         score: 'high', // Invalid
-        matching_criteria: {},
+        matchDetails: {},
         close_date: null,
         maximum_award: null,
         is_national: false,
+        source_type: null,
+        is_new: false,
+        first_matched_at: null,
       };
 
       const errors = validateSchema(match, matchSchema);
@@ -138,7 +152,7 @@ describe('Client Matching API Contract', () => {
     });
   });
 
-  describe('Matching Criteria Schema', () => {
+  describe('Match Details Schema', () => {
     test('validates all boolean criteria', () => {
       const criteria = {
         locationMatch: true,
@@ -147,7 +161,7 @@ describe('Client Matching API Contract', () => {
         activitiesMatch: true,
       };
 
-      const errors = validateSchema(criteria, matchingCriteriaSchema);
+      const errors = validateSchema(criteria, matchDetailsSchema);
       expect(errors).toHaveLength(0);
     });
 
@@ -158,51 +172,78 @@ describe('Client Matching API Contract', () => {
         // missing projectNeedsMatch and activitiesMatch
       };
 
-      const errors = validateSchema(incompleteCriteria, matchingCriteriaSchema);
+      const errors = validateSchema(incompleteCriteria, matchDetailsSchema);
       expect(errors.length).toBeGreaterThan(0);
     });
   });
 
   describe('List Response Shape', () => {
-    test('validates matches array response', () => {
-      const response = {
-        client_id: 'client-123',
-        client_name: 'City of SF',
-        matches: [
-          {
-            opportunity_id: 'opp-1',
-            opportunity_title: 'Grant 1',
-            agency_name: 'DOE',
-            score: 90,
-            matching_criteria: {
-              locationMatch: true,
-              applicantTypeMatch: true,
-              projectNeedsMatch: true,
-              activitiesMatch: true,
-            },
-            close_date: '2025-06-30',
-            maximum_award: 1000000,
-            is_national: true,
-          },
-        ],
-        total_matches: 1,
+    // Inline version of the single-client response shape from route.js handleSingleClient
+    function buildSingleClientResponse(client, matches, hiddenCount) {
+      return {
+        success: true,
+        results: {
+          client,
+          matches,
+          matchCount: matches.length,
+          hiddenCount,
+          topMatches: matches.slice(0, 3)
+        },
+        timestamp: new Date().toISOString()
       };
+    }
 
-      expect(Array.isArray(response.matches)).toBe(true);
-      expect(response.total_matches).toBe(1);
-      expect(response.client_id).toBe('client-123');
+    test('validates single-client response shape', () => {
+      const client = { id: 'client-123', name: 'City of SF' };
+      const matches = [
+        {
+          id: 'opp-1',
+          title: 'Grant 1',
+          agency_name: 'DOE',
+          score: 90,
+          matchDetails: {
+            locationMatch: true,
+            applicantTypeMatch: true,
+            projectNeedsMatch: true,
+            activitiesMatch: true,
+          },
+          close_date: '2025-06-30',
+          maximum_award: 1000000,
+          is_national: true,
+          source_type: 'federal',
+          is_new: true,
+          first_matched_at: '2025-06-01T00:00:00Z',
+        },
+      ];
+
+      const response = buildSingleClientResponse(client, matches, 0);
+      expect(response.success).toBe(true);
+      expect(Array.isArray(response.results.matches)).toBe(true);
+      expect(response.results.matchCount).toBe(1);
+      expect(response.results.client.id).toBe('client-123');
+      expect(response.results.topMatches).toHaveLength(1);
+      expect(response.timestamp).toBeDefined();
     });
 
     test('empty matches array is valid', () => {
-      const response = {
-        client_id: 'client-123',
-        client_name: 'New Client',
-        matches: [],
-        total_matches: 0,
-      };
+      const client = { id: 'client-123', name: 'New Client' };
+      const response = buildSingleClientResponse(client, [], 0);
 
-      expect(response.matches).toHaveLength(0);
-      expect(response.total_matches).toBe(0);
+      expect(response.results.matches).toHaveLength(0);
+      expect(response.results.matchCount).toBe(0);
+      expect(response.results.hiddenCount).toBe(0);
+    });
+
+    test('topMatches limited to 3', () => {
+      const client = { id: 'client-123', name: 'City of SF' };
+      const matches = Array.from({ length: 5 }, (_, i) => ({
+        id: `opp-${i}`, title: `Grant ${i}`, score: 90 - i * 5
+      }));
+      const response = buildSingleClientResponse(client, matches, 2);
+
+      expect(response.results.matchCount).toBe(5);
+      expect(response.results.topMatches).toHaveLength(3);
+      expect(response.results.hiddenCount).toBe(2);
     });
   });
 
@@ -239,7 +280,7 @@ describe('Client Matching API Contract', () => {
 
   describe('Promotion Status Filter (opportunity visibility)', () => {
     // Inline filter replicating: .neq('status', 'closed').or('promotion_status.is.null,promotion_status.eq.promoted')
-    // Used by client-matching, top-matches, and summary routes
+    // Used by lib/matching/computeMatches.js when fetching opportunities for match computation
     function filterVisibleOpportunities(opps) {
       return opps.filter(
         (o) =>
@@ -298,6 +339,143 @@ describe('Client Matching API Contract', () => {
       expect(visible).toHaveLength(2);
       expect(visibleIds).toContain('vis-1');
       expect(visibleIds).toContain('vis-2');
+    });
+  });
+
+  describe('is_new Field (from client_matches)', () => {
+    test('match object can include is_new boolean', () => {
+      const match = {
+        id: 'opp-123',
+        title: 'New Grant',
+        agency_name: 'DOE',
+        score: 85,
+        matchDetails: {
+          locationMatch: true,
+          applicantTypeMatch: true,
+          projectNeedsMatch: true,
+          activitiesMatch: true,
+        },
+        close_date: '2025-06-30',
+        maximum_award: 5000000,
+        is_national: true,
+        source_type: 'federal',
+        is_new: true,
+        first_matched_at: '2025-06-01T00:00:00Z',
+      };
+
+      expect(typeof match.is_new).toBe('boolean');
+      expect(match.is_new).toBe(true);
+    });
+
+    test('is_new defaults to true for new matches', () => {
+      const newMatch = { is_new: true };
+      const seenMatch = { is_new: false };
+      expect(newMatch.is_new).toBe(true);
+      expect(seenMatch.is_new).toBe(false);
+    });
+  });
+
+  describe('Match Transform (client_matches row to API shape)', () => {
+    // Inline version of transformMatch from the route
+    function transformMatch(row) {
+      const opp = row.opportunity;
+      return {
+        ...opp,
+        source_type: opp.funding_sources?.type || null,
+        funding_sources: undefined,
+        score: row.score,
+        matchDetails: row.match_details,
+        is_new: row.is_new,
+        first_matched_at: row.first_matched_at
+      };
+    }
+
+    test('maps match_details to matchDetails (camelCase)', () => {
+      const row = {
+        score: 75,
+        match_details: {
+          locationMatch: true,
+          applicantTypeMatch: true,
+          projectNeedsMatch: true,
+          activitiesMatch: true,
+          matchedProjectNeeds: ['Solar Installation']
+        },
+        is_new: true,
+        first_matched_at: '2025-06-01T00:00:00Z',
+        opportunity: {
+          id: 'opp-1',
+          title: 'Solar Grant',
+          agency_name: 'DOE',
+          funding_sources: { type: 'federal' }
+        }
+      };
+
+      const result = transformMatch(row);
+      expect(result.matchDetails).toEqual(row.match_details);
+      expect(result.matchDetails.matchedProjectNeeds).toEqual(['Solar Installation']);
+      expect(result.score).toBe(75);
+      expect(result.is_new).toBe(true);
+      expect(result.first_matched_at).toBe('2025-06-01T00:00:00Z');
+      expect(result.source_type).toBe('federal');
+      expect(result.funding_sources).toBeUndefined();
+    });
+
+    test('handles null funding_sources gracefully', () => {
+      const row = {
+        score: 50,
+        match_details: {},
+        is_new: false,
+        first_matched_at: '2025-05-15T00:00:00Z',
+        opportunity: {
+          id: 'opp-2',
+          title: 'State Grant',
+          funding_sources: null
+        }
+      };
+
+      const result = transformMatch(row);
+      expect(result.source_type).toBeNull();
+      expect(result.first_matched_at).toBe('2025-05-15T00:00:00Z');
+    });
+  });
+
+  describe('Hidden Match Filtering (query-time)', () => {
+    // Inline version of the hidden matches filtering logic
+    function filterHiddenMatches(matchRows, hiddenIds) {
+      const hiddenSet = new Set(hiddenIds);
+      return matchRows.filter(row => !hiddenSet.has(row.opportunity_id));
+    }
+
+    test('excludes hidden opportunity IDs', () => {
+      const rows = [
+        { opportunity_id: 'opp-1', score: 90 },
+        { opportunity_id: 'opp-2', score: 80 },
+        { opportunity_id: 'opp-3', score: 70 },
+      ];
+      const hidden = ['opp-2'];
+
+      const visible = filterHiddenMatches(rows, hidden);
+      expect(visible).toHaveLength(2);
+      expect(visible.map(r => r.opportunity_id)).toEqual(['opp-1', 'opp-3']);
+    });
+
+    test('returns all when no hidden matches', () => {
+      const rows = [
+        { opportunity_id: 'opp-1', score: 90 },
+        { opportunity_id: 'opp-2', score: 80 },
+      ];
+
+      const visible = filterHiddenMatches(rows, []);
+      expect(visible).toHaveLength(2);
+    });
+
+    test('returns empty when all hidden', () => {
+      const rows = [
+        { opportunity_id: 'opp-1', score: 90 },
+      ];
+
+      const visible = filterHiddenMatches(rows, ['opp-1']);
+      expect(visible).toHaveLength(0);
     });
   });
 
@@ -571,6 +749,55 @@ describe('Client Matching API Contract', () => {
 
       expect(response.success).toBe(false);
       expect(response.error).toContain('opportunityId');
+    });
+  });
+
+  describe('POST /api/client-matching/mark-seen Response', () => {
+    // Inline version of input validation from mark-seen/route.js
+    function validateMarkSeenInput(body) {
+      if (!body || !body.clientId) {
+        return { valid: false, error: 'clientId is required', status: 400 };
+      }
+      return { valid: true };
+    }
+
+    // Inline version of response building from mark-seen/route.js
+    function buildMarkSeenResponse(dbError) {
+      if (dbError) {
+        return { body: { error: 'Failed to mark matches as seen' }, status: 500 };
+      }
+      return { body: { success: true }, status: 200 };
+    }
+
+    test('valid clientId passes validation', () => {
+      const result = validateMarkSeenInput({ clientId: 'client-123' });
+      expect(result.valid).toBe(true);
+    });
+
+    test('missing clientId fails validation with 400', () => {
+      const result = validateMarkSeenInput({});
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('clientId is required');
+      expect(result.status).toBe(400);
+    });
+
+    test('null body fails validation with 400', () => {
+      const result = validateMarkSeenInput(null);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('clientId is required');
+      expect(result.status).toBe(400);
+    });
+
+    test('successful DB update returns success', () => {
+      const response = buildMarkSeenResponse(null);
+      expect(response.body.success).toBe(true);
+      expect(response.status).toBe(200);
+    });
+
+    test('DB error returns 500', () => {
+      const response = buildMarkSeenResponse({ message: 'DB connection failed' });
+      expect(response.body.error).toBe('Failed to mark matches as seen');
+      expect(response.status).toBe(500);
     });
   });
 });

--- a/tests/pipeline/matchComputation.test.js
+++ b/tests/pipeline/matchComputation.test.js
@@ -199,6 +199,70 @@ describe('Match Computation: Job Logging', () => {
   });
 });
 
+describe('Match Computation: First-Time Client Detection', () => {
+  /**
+   * Identify clients with zero prior matches (first-ever computation).
+   * Mirrors lib/matching/computeMatches.js lines 160-167.
+   */
+  function identifyFirstTimeClients(clients, existingMatches) {
+    const clientsWithExistingMatches = new Set(
+      (existingMatches || []).map(m => m.client_id)
+    );
+    return clients
+      .map(c => c.id)
+      .filter(cid => !clientsWithExistingMatches.has(cid));
+  }
+
+  test('brand new clients with no existing matches are identified', () => {
+    const clients = [
+      { id: 'c1' },
+      { id: 'c2' },
+      { id: 'c3' },
+    ];
+    const existingMatches = [
+      { client_id: 'c1', opportunity_id: 'opp-1' },
+    ];
+
+    const firstTime = identifyFirstTimeClients(clients, existingMatches);
+    expect(firstTime).toEqual(['c2', 'c3']);
+  });
+
+  test('all clients are first-time when no existing matches', () => {
+    const clients = [{ id: 'c1' }, { id: 'c2' }];
+    const firstTime = identifyFirstTimeClients(clients, []);
+    expect(firstTime).toEqual(['c1', 'c2']);
+  });
+
+  test('no first-time clients when all have existing matches', () => {
+    const clients = [{ id: 'c1' }, { id: 'c2' }];
+    const existingMatches = [
+      { client_id: 'c1', opportunity_id: 'opp-1' },
+      { client_id: 'c2', opportunity_id: 'opp-2' },
+    ];
+
+    const firstTime = identifyFirstTimeClients(clients, existingMatches);
+    expect(firstTime).toEqual([]);
+  });
+
+  test('handles null existingMatches gracefully', () => {
+    const clients = [{ id: 'c1' }];
+    const firstTime = identifyFirstTimeClients(clients, null);
+    expect(firstTime).toEqual(['c1']);
+  });
+
+  test('a client with any match is not first-time (even one)', () => {
+    const clients = [{ id: 'c1' }, { id: 'c2' }];
+    const existingMatches = [
+      { client_id: 'c1', opportunity_id: 'opp-1' },
+      { client_id: 'c1', opportunity_id: 'opp-2' },
+      // c2 has no matches — it's first-time
+    ];
+
+    const firstTime = identifyFirstTimeClients(clients, existingMatches);
+    expect(firstTime).toEqual(['c2']);
+  });
+});
+
 describe('Match Computation: Scoped vs Full', () => {
   test('client-scoped computation only processes that client', () => {
     // Simulate: 1 client, all opportunities


### PR DESCRIPTION
## Summary
- Rewrite `/api/client-matching`, `/summary`, `/top-matches`, and PDF export routes to query `client_matches` table instead of recomputing O(n*m) matches on every request
- Add `is_new` badges (blue "NEW MATCH") with 7-day time-based aging on client cards and match detail pages
- Add first-time client detection to prevent false-positive badges on initial match computation
- Add `.limit(10000)` to all Supabase queries to prevent silent row truncation
- Update `compute-matches` cron auth to support Vercel cron header, CRON_SECRET, and dev mode
- Add seed-matches build script for initial deployment

## Test plan
- [x] `npm run test:critical` — 1178 tests pass
- [x] `npm run test:api` — 262 tests pass
- [x] `npm run build` — succeeds
- [x] Browser verification: client cards show "NEW MATCH • Today", detail page shows badges, badges persist after refresh
- [x] First-time client gets `is_new=false` on all initial matches
- [x] Delta matches (new opportunities added later) get `is_new=true`

Relates to #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)