### PR TITLE
Redesign client match detail page with funding type grouping

### DIFF
--- a/app/clients/[clientId]/matches/page.jsx
+++ b/app/clients/[clientId]/matches/page.jsx
@@ -6,15 +6,21 @@ import MainLayout from '@/components/layout/main-layout';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { AlertTriangle, Loader2, ArrowLeft, User, MapPin, Building, DollarSign, Target, EyeOff } from 'lucide-react';
+import { AlertTriangle, Loader2, ArrowLeft, MapPin, Building, DollarSign, Target, EyeOff } from 'lucide-react';
 import { ExportPDFButton } from '@/components/clients/ExportPDFButton';
 import { HideMatchButton } from '@/components/clients/HideMatchButton';
 import { HiddenMatchesPanel } from '@/components/clients/HiddenMatchesPanel';
 import Link from 'next/link';
 import OpportunityCard from '@/components/opportunities/OpportunityCard';
-import { fetchClientMatches, formatMatchScore, getMatchScoreBgColor, generateClientTags, formatProjectNeeds } from '@/lib/utils/clientMatching';
+import {
+	fetchClientMatches,
+	formatMatchScore,
+	generateProjectNeedsWithCounts,
+	groupMatchesByFundingType,
+	getMatchScoreBadgeStyles,
+	getFundingGroupDotColor,
+} from '@/lib/utils/clientMatching';
 
 export default function ClientMatchesPage() {
 	const params = useParams();
@@ -46,7 +52,6 @@ export default function ClientMatchesPage() {
 		}
 	}, [clientId, loadClientMatches]);
 
-	// Handler for when a match is hidden
 	const handleMatchHidden = useCallback((opportunityId) => {
 		setClientResult(prev => ({
 			...prev,
@@ -56,9 +61,7 @@ export default function ClientMatchesPage() {
 		setHiddenCount(prev => prev + 1);
 	}, []);
 
-	// Handler for when a match is restored
 	const handleMatchRestored = useCallback(() => {
-		// Refetch matches to get the restored one
 		loadClientMatches();
 	}, [loadClientMatches]);
 
@@ -106,17 +109,34 @@ export default function ClientMatchesPage() {
 	}
 
 	const { client, matches, matchCount } = clientResult;
-	const tags = generateClientTags(client, matches, null); // Show all project needs on detail page
 
-	// Budget labels for display
+	// Merged project needs with match counts
+	const needsWithCounts = generateProjectNeedsWithCounts(client.project_needs, matches);
+
+	// Group matches by funding type, sorted by relevance within each group
+	const groupedMatches = groupMatchesByFundingType(matches);
+
+	// Budget formatting with numeric fallback
 	const budgetLabels = {
 		small: 'Small ($50K - $500K)',
 		medium: 'Medium ($500K - $5M)',
 		large: 'Large ($5M - $50M)',
 		very_large: 'Very Large ($50M+)'
 	};
+	const budgetDisplay = budgetLabels[client.budget]
+		|| (typeof client.budget === 'number'
+			? `$${client.budget.toLocaleString()}`
+			: (typeof client.budget === 'string' && client.budget !== '' && !isNaN(Number(client.budget))
+				? `$${Number(client.budget).toLocaleString()}`
+				: client.budget || 'Not specified'));
 
-	const budgetDisplay = budgetLabels[client.budget] || client.budget || 'Not specified';
+	// Grouped summary for header badge (e.g., "3 Grants, 1 Tax Benefit")
+	const groupedSummary = matchCount === 0
+		? '0 Matches'
+		: groupedMatches.map(g => {
+			const label = g.matches.length === 1 ? g.label.replace(/s$/, '') : g.label;
+			return `${g.matches.length} ${label}`;
+		}).join(', ');
 
 	return (
 		<MainLayout>
@@ -133,91 +153,83 @@ export default function ClientMatchesPage() {
 				</div>
 
 				{/* Client Header */}
-				<div className='mb-8'>
-					<div className='flex items-start justify-between mb-4'>
+				<div className='mb-4'>
+					<div className='flex items-start justify-between mb-3'>
 						<div>
-							<h1 className='text-3xl font-bold mb-2'>{client.name}</h1>
-							<div className='flex items-center gap-4 text-sm text-muted-foreground'>
+							<h1 className='text-4xl font-bold tracking-tight mb-2'>{client.name}</h1>
+							<div className='flex items-center gap-3 text-[13px] text-muted-foreground'>
 								<div className='flex items-center gap-1'>
 									<Building className='h-4 w-4' />
-									{client.type}
+									<span className='font-medium text-neutral-800 dark:text-neutral-200'>{client.type}</span>
 								</div>
+								<span className='text-neutral-300 dark:text-neutral-600 select-none'>&middot;</span>
 								<div className='flex items-center gap-1'>
 									<MapPin className='h-4 w-4' />
-									{[client.city, client.state_code].filter(Boolean).join(', ') || client.address}
+									<span className='font-medium text-neutral-800 dark:text-neutral-200'>
+										{[client.city, client.state_code].filter(Boolean).join(', ') || client.address}
+									</span>
 								</div>
+								<span className='text-neutral-300 dark:text-neutral-600 select-none'>&middot;</span>
 								<div className='flex items-center gap-1'>
 									<DollarSign className='h-4 w-4' />
-									{budgetDisplay}
+									<span className='font-medium text-neutral-800 dark:text-neutral-200'>{budgetDisplay}</span>
 								</div>
 							</div>
 						</div>
-						<Badge variant='outline' className='text-lg px-3 py-1'>
-							{matchCount} {matchCount === 1 ? 'Match' : 'Matches'}
+						<Badge variant='outline' className='text-sm px-3 py-1 whitespace-nowrap'>
+							{groupedSummary}
 						</Badge>
 					</div>
-
-					{/* Client Details Card */}
-					<Card>
-						<CardHeader>
-							<CardTitle className='flex items-center gap-2'>
-								<User className='h-5 w-5' />
-								Client Profile
-							</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<div className='space-y-4'>
-								{/* Description */}
-								{client.description && (
-									<div>
-										<h4 className='font-medium mb-2'>About</h4>
-										<p className='text-sm text-muted-foreground'>{client.description}</p>
-									</div>
-								)}
-
-								{/* Project Needs */}
-								<div>
-									<h4 className='font-medium mb-2 flex items-center gap-2'>
-										<Target className='h-4 w-4' />
-										Project Needs
-									</h4>
-									<div className='flex flex-wrap gap-2'>
-										{formatProjectNeeds(client.project_needs).map((need, index) => (
-											<Badge
-												key={index}
-												variant='outline'
-												className='px-3 py-1 bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-300'
-											>
-												{need}
-											</Badge>
-										))}
-									</div>
-									{(!client.project_needs || client.project_needs.length === 0) && (
-										<p className='text-sm text-muted-foreground italic'>No project needs specified</p>
-									)}
-								</div>
-
-								{/* Match Breakdown */}
-								<div>
-									<h4 className='font-medium mb-2'>Match Breakdown</h4>
-									<div className='flex flex-wrap gap-2'>
-										{tags.map((tag, index) => (
-											<Badge key={index} variant='secondary'>
-												{tag}
-											</Badge>
-										))}
-									</div>
-								</div>
-							</div>
-						</CardContent>
-					</Card>
 				</div>
 
-				{/* Matches Section */}
+				{/* Client Profile — lightweight section */}
+				<div className='mb-6 rounded-lg border border-neutral-200 dark:border-neutral-800 border-l-[4px] border-l-blue-500 bg-blue-50/30 dark:bg-blue-950/20 px-5 py-4'>
+					<p className='text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400 mb-3'>
+						Client Profile
+					</p>
+					<div className='space-y-3'>
+						{/* Description */}
+						{client.description && (
+							<div>
+								<p className='text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed'>{client.description}</p>
+							</div>
+						)}
+
+						{/* Project Needs with match counts (merged) */}
+						<div>
+							<p className='text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400 mb-2 flex items-center gap-2'>
+								<Target className='h-3.5 w-3.5' />
+								Project Needs
+							</p>
+							<div className='flex flex-wrap gap-2'>
+								{needsWithCounts.map((item, index) => (
+									<Badge
+										key={index}
+										variant='outline'
+										className={`px-3 py-1 text-xs ${
+											item.count > 0
+												? 'bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-800'
+												: 'bg-white text-neutral-500 border-neutral-300 dark:bg-neutral-800 dark:text-neutral-400 dark:border-neutral-600'
+										}`}
+									>
+										{item.count > 0 ? `${item.need} (${item.count})` : item.need}
+									</Badge>
+								))}
+							</div>
+							{(!client.project_needs || client.project_needs.length === 0) && (
+								<p className='text-sm text-muted-foreground italic'>No project needs specified</p>
+							)}
+						</div>
+					</div>
+				</div>
+
+				{/* Funding Opportunities — grouped by type */}
 				<div className='mb-6'>
 					<Tabs value={activeTab} onValueChange={setActiveTab}>
 						<div className='flex items-center justify-between mb-4'>
-							<h2 className='text-2xl font-bold'>Funding Opportunities</h2>
+							<h2 className='text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50'>
+								Funding Opportunities
+							</h2>
 							<TabsList>
 								<TabsTrigger value='matches'>
 									Matches ({matchCount})
@@ -231,29 +243,55 @@ export default function ClientMatchesPage() {
 
 						<TabsContent value='matches'>
 							{matchCount > 0 ? (
-								<div className='grid gap-6 md:grid-cols-2 lg:grid-cols-3'>
-									{matches.map((match) => (
-										<div key={match.id} className='relative group'>
-											<OpportunityCard
-												opportunity={match}
-												badgeOverride={
-													<span
-														className='text-xs px-2 py-1 rounded-full flex-shrink-0 ml-2 font-medium'
-														style={getMatchScoreBgColor(match.score)}
-													>
-														{formatMatchScore(match.score)}
-													</span>
-												}
-											/>
-											<div className='absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity'>
-												<HideMatchButton
-													clientId={clientId}
-													opportunityId={match.id}
-													opportunityTitle={match.title}
-													onHidden={handleMatchHidden}
-												/>
+								<div className='space-y-8'>
+									{groupedMatches.map((group, groupIndex) => (
+										<section key={group.key}>
+											{/* Group header */}
+											<div className={`flex items-center gap-3 mb-4 ${groupIndex > 0 ? 'pt-6 border-t border-neutral-200 dark:border-neutral-800' : ''}`}>
+												<span className='w-2 h-2 rounded-full flex-shrink-0' style={{ backgroundColor: getFundingGroupDotColor(group.key) }} />
+												<h3 className='text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400'>
+													{group.label}
+												</h3>
+												<span className='text-xs text-neutral-400 dark:text-neutral-500'>
+													{group.description}
+												</span>
+												<div className='flex-1 h-px bg-neutral-200 dark:bg-neutral-800' />
+												<Badge variant='secondary' className='text-xs'>
+													{group.matches.length}
+												</Badge>
 											</div>
-										</div>
+
+											{/* Cards grid */}
+											<div className='grid gap-6 sm:grid-cols-2 lg:grid-cols-3'>
+												{group.matches.map((match) => (
+													<div key={match.id} className='rounded-lg overflow-hidden border border-neutral-200 dark:border-neutral-700 flex flex-col'>
+														{/* Top accent bar */}
+														<div className='h-1.5 w-full bg-blue-500 dark:bg-blue-400' />
+														{/* Match context strip */}
+														<div className='flex items-center justify-between px-3 py-2 bg-neutral-100/80 dark:bg-neutral-800/60 border-b border-neutral-200 dark:border-neutral-700'>
+															<span
+																className='text-xs font-medium px-2 py-0.5 rounded-full'
+																style={getMatchScoreBadgeStyles(match.score)}
+															>
+																{formatMatchScore(match.score)}
+															</span>
+															<HideMatchButton
+																clientId={clientId}
+																opportunityId={match.id}
+																opportunityTitle={match.title}
+																onHidden={handleMatchHidden}
+															/>
+														</div>
+														{/* Card — border/radius nullified, internal accent bars hidden (outer wrapper provides them) */}
+														<div className='[&>a>div]:border-0 [&>a>div]:rounded-none [&>a]:rounded-none [&_.bg-blue-500]:hidden [&_.dark\:bg-blue-400]:hidden flex-grow'>
+															<OpportunityCard opportunity={match} />
+														</div>
+														{/* Bottom accent bar */}
+														<div className='h-1.5 w-full bg-blue-500 dark:bg-blue-400' />
+													</div>
+												))}
+											</div>
+										</section>
 									))}
 								</div>
 							) : (
@@ -261,7 +299,7 @@ export default function ClientMatchesPage() {
 									<AlertTriangle className='h-4 w-4' />
 									<AlertTitle>No Matches Found</AlertTitle>
 									<AlertDescription>
-										No funding opportunities currently match this client's criteria. Try adjusting the client's project needs or location requirements.
+										No funding opportunities currently match this client&apos;s criteria. Try adjusting the client&apos;s project needs or location requirements.
 									</AlertDescription>
 								</Alert>
 							)}

--- a/lib/constants/taxonomies.js
+++ b/lib/constants/taxonomies.js
@@ -306,31 +306,31 @@ export const TAXONOMIES = {
 			// Direct Funding - MOST VALUABLE
 			'Grant',
 			'Direct Payment',
-			'Voucher',
-			'Rebate',
 		],
 
 		strong: [
-			// Tax Benefits - STRONG VALUE, NO REPAYMENT
+			// Upfront value or near-grant mechanisms - STRONG VALUE, NO REPAYMENT
 			'Tax Credit',
 			'Tax Incentive',
 			'Tax Deduction',
 			'Tax Exemption',
+			'Voucher',
+			'Cooperative Agreement',
 		],
 
 		mild: [
-			// Loans & Credit - NEEDS REPAYMENT
+			// Loans, credit & delayed-value mechanisms - NEEDS REPAYMENT OR DELAYED
 			'Loan',
 			'Forgivable Loan',
 			'Guarantee',
 			'Bond',
+			'Rebate',
 		],
 
 		weak: [
-			// Support Services & Agreements - NON-MONETARY
+			// Support Services - NON-MONETARY
 			'Technical Assistance',
 			'In-Kind Support',
-			'Cooperative Agreement',
 			'Contract',
 		],
 	},
@@ -895,5 +895,43 @@ export function getSelectableClientTypes() {
 
 	return Array.from(selectableTypes).sort();
 }
+
+/**
+ * Funding type display groups for UI — ordered by desirability.
+ * Used by client matches, opportunity explorer, and any view that groups by funding type.
+ * The "other" group is a catch-all for types not explicitly listed (e.g., Technical Assistance, Contract).
+ */
+export const FUNDING_TYPE_GROUPS = [
+	{
+		key: 'grants',
+		label: 'Grants',
+		description: 'Direct Grant Funding',
+		types: ['Grant', 'Cooperative Agreement'],
+	},
+	{
+		key: 'tax',
+		label: 'Tax Benefits',
+		description: 'Tax Incentives',
+		types: ['Tax Credit', 'Tax Incentive', 'Tax Deduction', 'Tax Exemption'],
+	},
+	{
+		key: 'loans',
+		label: 'Loans',
+		description: 'Loans & Credit',
+		types: ['Loan', 'Forgivable Loan', 'Guarantee', 'Bond'],
+	},
+	{
+		key: 'incentives',
+		label: 'Rebates & Incentives',
+		description: 'Utility Incentives',
+		types: ['Rebate', 'Direct Payment', 'Voucher'],
+	},
+	{
+		key: 'other',
+		label: 'Other',
+		description: 'Support & Services',
+		types: [], // catch-all for anything not in the above groups
+	},
+];
 
 export default TAXONOMIES;

--- a/lib/utils/clientMatching.js
+++ b/lib/utils/clientMatching.js
@@ -4,6 +4,8 @@
  * Shared utilities for client-opportunity matching functionality
  */
 
+import { FUNDING_TYPE_GROUPS } from '@/lib/constants/taxonomies';
+
 /**
  * Fetch matches for a specific client or all clients
  */
@@ -105,6 +107,98 @@ export function generateClientTags(client, matches = [], limit = 3) {
   const limitedNeeds = limit ? sortedNeeds.slice(0, limit) : sortedNeeds;
 
   return limitedNeeds.map(([need, count]) => `${need} (${count})`);
+}
+
+/**
+ * Generate project needs with match counts (merged view)
+ * @param {Array} projectNeeds - Client's project_needs array
+ * @param {Array} matches - Array of match objects with matchDetails
+ * @returns {Array} Array of { need, count } objects
+ */
+export function generateProjectNeedsWithCounts(projectNeeds, matches = []) {
+  if (!projectNeeds || !Array.isArray(projectNeeds) || projectNeeds.length === 0) return [];
+
+  // Build match count map
+  const countMap = new Map();
+  if (Array.isArray(matches)) {
+    matches.forEach(match => {
+      const matchedNeeds = match.matchDetails?.matchedProjectNeeds || [];
+      matchedNeeds.forEach(need => {
+        countMap.set(need, (countMap.get(need) || 0) + 1);
+      });
+    });
+  }
+
+  return projectNeeds.map(need => ({
+    need,
+    count: countMap.get(need) || 0,
+  }));
+}
+
+/**
+ * Get relevance score from an opportunity, with fallbacks
+ */
+function getRelevanceScore(opportunity) {
+  return opportunity.relevance_score
+    || opportunity.scoring?.finalScore
+    || opportunity.scoring?.overallScore
+    || 0;
+}
+
+/**
+ * Group matches by funding type category, sorted by relevance within each group
+ * @param {Array} matches - Array of match/opportunity objects
+ * @returns {Array} Array of { key, label, description, matches } group objects (non-empty only)
+ */
+export function groupMatchesByFundingType(matches) {
+  if (!matches || !Array.isArray(matches) || matches.length === 0) return [];
+
+  // Build a lookup: funding type string → group index
+  const typeToGroup = new Map();
+  FUNDING_TYPE_GROUPS.forEach((group, index) => {
+    group.types.forEach(type => typeToGroup.set(type, index));
+  });
+
+  // Distribute matches into groups
+  const groups = FUNDING_TYPE_GROUPS.map(g => ({ ...g, matches: [] }));
+
+  matches.forEach(match => {
+    const fundingType = match.funding_type || '';
+    const groupIndex = typeToGroup.has(fundingType) ? typeToGroup.get(fundingType) : groups.length - 1;
+    groups[groupIndex].matches.push(match);
+  });
+
+  // Sort within each group by relevance_score descending
+  groups.forEach(group => {
+    group.matches.sort((a, b) => getRelevanceScore(b) - getRelevanceScore(a));
+  });
+
+  // Return only non-empty groups
+  return groups.filter(g => g.matches.length > 0);
+}
+
+/**
+ * Get match score badge inline styles (border-only pill style)
+ * Uses inline styles to avoid Tailwind JIT purging dynamic classes (e.g. violet-*)
+ */
+export function getMatchScoreBadgeStyles(score) {
+  if (score >= 60) return { backgroundColor: '#f5f3ff', color: '#6d28d9', border: '1px solid #c4b5fd' }; // violet-50/700/300
+  if (score >= 30) return { backgroundColor: '#fffbeb', color: '#b45309', border: '1px solid #fcd34d' }; // amber-50/700/300
+  return { backgroundColor: '#f9fafb', color: '#6b7280', border: '1px solid #d1d5db' }; // neutral-50/500/300
+}
+
+/**
+ * Get color for funding type group header dots (inline style to avoid Tailwind JIT issues)
+ */
+export function getFundingGroupDotColor(key) {
+  const colors = {
+    grants: '#10b981',      // emerald-500
+    incentives: '#8b5cf6',  // violet-500
+    tax: '#f59e0b',         // amber-500
+    loans: '#3b82f6',       // blue-500
+    other: '#a3a3a3',       // neutral-400
+  };
+  return colors[key] || colors.other;
 }
 
 /**

--- a/tests/critical/client-matching/clientMatchingUtils.test.js
+++ b/tests/critical/client-matching/clientMatchingUtils.test.js
@@ -542,3 +542,411 @@ describe('generateClientTags', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// New inline pure functions — added for match page redesign
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate project needs with match counts (merged view)
+ * (Logic from clientMatching.js:generateProjectNeedsWithCounts)
+ */
+function generateProjectNeedsWithCounts(projectNeeds, matches = []) {
+  if (!projectNeeds || !Array.isArray(projectNeeds) || projectNeeds.length === 0) return [];
+
+  const countMap = new Map();
+  if (Array.isArray(matches)) {
+    matches.forEach(match => {
+      const matchedNeeds = match.matchDetails?.matchedProjectNeeds || [];
+      matchedNeeds.forEach(need => {
+        countMap.set(need, (countMap.get(need) || 0) + 1);
+      });
+    });
+  }
+
+  return projectNeeds.map(need => ({
+    need,
+    count: countMap.get(need) || 0,
+  }));
+}
+
+/**
+ * Funding type group definitions, ordered by desirability
+ * (Logic from clientMatching.js:FUNDING_TYPE_GROUPS)
+ */
+const FUNDING_TYPE_GROUPS = [
+  {
+    key: 'grants',
+    label: 'Grants',
+    description: 'Direct Grant Funding',
+    types: ['Grant', 'Cooperative Agreement'],
+  },
+  {
+    key: 'tax',
+    label: 'Tax Benefits',
+    description: 'Tax Incentives',
+    types: ['Tax Credit', 'Tax Incentive', 'Tax Deduction', 'Tax Exemption'],
+  },
+  {
+    key: 'loans',
+    label: 'Loans',
+    description: 'Loans & Credit',
+    types: ['Loan', 'Forgivable Loan', 'Guarantee', 'Bond'],
+  },
+  {
+    key: 'incentives',
+    label: 'Rebates & Incentives',
+    description: 'Utility Incentives',
+    types: ['Rebate', 'Direct Payment', 'Voucher'],
+  },
+  {
+    key: 'other',
+    label: 'Other',
+    description: 'Support & Services',
+    types: [],
+  },
+];
+
+function getRelevanceScore(opportunity) {
+  return opportunity.relevance_score
+    || opportunity.scoring?.finalScore
+    || opportunity.scoring?.overallScore
+    || 0;
+}
+
+/**
+ * Group matches by funding type category
+ * (Logic from clientMatching.js:groupMatchesByFundingType)
+ */
+function groupMatchesByFundingType(matches) {
+  if (!matches || !Array.isArray(matches) || matches.length === 0) return [];
+
+  const typeToGroup = new Map();
+  FUNDING_TYPE_GROUPS.forEach((group, index) => {
+    group.types.forEach(type => typeToGroup.set(type, index));
+  });
+
+  const groups = FUNDING_TYPE_GROUPS.map(g => ({ ...g, matches: [] }));
+
+  matches.forEach(match => {
+    const fundingType = match.funding_type || '';
+    const groupIndex = typeToGroup.has(fundingType) ? typeToGroup.get(fundingType) : groups.length - 1;
+    groups[groupIndex].matches.push(match);
+  });
+
+  groups.forEach(group => {
+    group.matches.sort((a, b) => getRelevanceScore(b) - getRelevanceScore(a));
+  });
+
+  return groups.filter(g => g.matches.length > 0);
+}
+
+/**
+ * Get match score badge inline styles
+ * (Logic from clientMatching.js:getMatchScoreBadgeStyles)
+ */
+function getMatchScoreBadgeStyles(score) {
+  if (score >= 60) return { backgroundColor: '#f5f3ff', color: '#6d28d9', border: '1px solid #c4b5fd' };
+  if (score >= 30) return { backgroundColor: '#fffbeb', color: '#b45309', border: '1px solid #fcd34d' };
+  return { backgroundColor: '#f9fafb', color: '#6b7280', border: '1px solid #d1d5db' };
+}
+
+/**
+ * Get funding group dot color
+ * (Logic from clientMatching.js:getFundingGroupDotColor)
+ */
+function getFundingGroupDotColor(key) {
+  const colors = {
+    grants: '#10b981',
+    incentives: '#8b5cf6',
+    tax: '#f59e0b',
+    loans: '#3b82f6',
+    other: '#a3a3a3',
+  };
+  return colors[key] || colors.other;
+}
+
+/**
+ * Budget display formatting
+ * (Logic from matches/page.jsx budget formatting)
+ */
+function formatBudgetDisplay(budget) {
+  const budgetLabels = {
+    small: 'Small ($50K - $500K)',
+    medium: 'Medium ($500K - $5M)',
+    large: 'Large ($5M - $50M)',
+    very_large: 'Very Large ($50M+)',
+  };
+  return budgetLabels[budget]
+    || (typeof budget === 'number'
+      ? `$${budget.toLocaleString()}`
+      : (typeof budget === 'string' && budget !== '' && !isNaN(Number(budget))
+        ? `$${Number(budget).toLocaleString()}`
+        : budget || 'Not specified'));
+}
+
+// ---------------------------------------------------------------------------
+// Tests — New functions
+// ---------------------------------------------------------------------------
+
+describe('generateProjectNeedsWithCounts', () => {
+  function buildMatch(matchedProjectNeeds) {
+    return { matchDetails: { matchedProjectNeeds } };
+  }
+
+  test('returns needs with zero counts when no matches', () => {
+    const result = generateProjectNeedsWithCounts(['Solar', 'HVAC'], []);
+    expect(result).toEqual([
+      { need: 'Solar', count: 0 },
+      { need: 'HVAC', count: 0 },
+    ]);
+  });
+
+  test('counts matched needs correctly', () => {
+    const matches = [
+      buildMatch(['Solar', 'HVAC']),
+      buildMatch(['Solar']),
+    ];
+    const result = generateProjectNeedsWithCounts(['Solar', 'HVAC', 'Wind'], matches);
+    expect(result).toEqual([
+      { need: 'Solar', count: 2 },
+      { need: 'HVAC', count: 1 },
+      { need: 'Wind', count: 0 },
+    ]);
+  });
+
+  test('preserves project needs order', () => {
+    const matches = [buildMatch(['Z', 'A'])];
+    const result = generateProjectNeedsWithCounts(['A', 'Z'], matches);
+    expect(result[0].need).toBe('A');
+    expect(result[1].need).toBe('Z');
+  });
+
+  test('returns empty array for null projectNeeds', () => {
+    expect(generateProjectNeedsWithCounts(null, [])).toEqual([]);
+  });
+
+  test('returns empty array for empty projectNeeds', () => {
+    expect(generateProjectNeedsWithCounts([], [])).toEqual([]);
+  });
+
+  test('handles matches with no matchDetails', () => {
+    const matches = [{ matchDetails: null }, {}];
+    const result = generateProjectNeedsWithCounts(['Solar'], matches);
+    expect(result).toEqual([{ need: 'Solar', count: 0 }]);
+  });
+});
+
+describe('groupMatchesByFundingType', () => {
+  test('returns empty array for null/empty matches', () => {
+    expect(groupMatchesByFundingType(null)).toEqual([]);
+    expect(groupMatchesByFundingType([])).toEqual([]);
+    expect(groupMatchesByFundingType(undefined)).toEqual([]);
+  });
+
+  test('groups grants correctly', () => {
+    const matches = [
+      { funding_type: 'Grant', relevance_score: 8 },
+      { funding_type: 'Cooperative Agreement', relevance_score: 6 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('grants');
+    expect(groups[0].matches).toHaveLength(2);
+  });
+
+  test('groups rebates/incentives correctly', () => {
+    const matches = [
+      { funding_type: 'Rebate', relevance_score: 7 },
+      { funding_type: 'Direct Payment', relevance_score: 5 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('incentives');
+    expect(groups[0].matches).toHaveLength(2);
+  });
+
+  test('groups tax benefits correctly', () => {
+    const matches = [
+      { funding_type: 'Tax Credit', relevance_score: 7 },
+      { funding_type: 'Tax Exemption', relevance_score: 9 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('tax');
+    expect(groups[0].matches).toHaveLength(2);
+  });
+
+  test('groups loans correctly', () => {
+    const matches = [
+      { funding_type: 'Loan', relevance_score: 5 },
+      { funding_type: 'Forgivable Loan', relevance_score: 8 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('loans');
+  });
+
+  test('unknown funding types go to "other"', () => {
+    const matches = [
+      { funding_type: 'Technical Assistance', relevance_score: 4 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('other');
+  });
+
+  test('multiple groups returned in order: grants → tax → loans → incentives', () => {
+    const matches = [
+      { funding_type: 'Tax Credit', relevance_score: 7 },
+      { funding_type: 'Grant', relevance_score: 9 },
+      { funding_type: 'Loan', relevance_score: 5 },
+      { funding_type: 'Rebate', relevance_score: 4 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(4);
+    expect(groups[0].key).toBe('grants');
+    expect(groups[1].key).toBe('tax');
+    expect(groups[2].key).toBe('loans');
+    expect(groups[3].key).toBe('incentives');
+  });
+
+  test('empty groups are excluded', () => {
+    const matches = [{ funding_type: 'Grant', relevance_score: 8 }];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('grants');
+  });
+
+  test('matches within a group are sorted by relevance score descending', () => {
+    const matches = [
+      { funding_type: 'Grant', relevance_score: 3 },
+      { funding_type: 'Grant', relevance_score: 9 },
+      { funding_type: 'Grant', relevance_score: 6 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups[0].matches[0].relevance_score).toBe(9);
+    expect(groups[0].matches[1].relevance_score).toBe(6);
+    expect(groups[0].matches[2].relevance_score).toBe(3);
+  });
+
+  test('uses scoring.finalScore as fallback for relevance', () => {
+    const matches = [
+      { funding_type: 'Grant', scoring: { finalScore: 4 } },
+      { funding_type: 'Grant', scoring: { finalScore: 8 } },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups[0].matches[0].scoring.finalScore).toBe(8);
+    expect(groups[0].matches[1].scoring.finalScore).toBe(4);
+  });
+
+  test('missing funding_type goes to other', () => {
+    const matches = [{ relevance_score: 5 }];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups[0].key).toBe('other');
+  });
+});
+
+describe('getMatchScoreBadgeStyles', () => {
+  test('60+ returns violet style', () => {
+    const style = getMatchScoreBadgeStyles(60);
+    expect(style.backgroundColor).toBe('#f5f3ff');
+    expect(style.color).toBe('#6d28d9');
+    expect(style.border).toContain('#c4b5fd');
+  });
+
+  test('100 returns violet style', () => {
+    expect(getMatchScoreBadgeStyles(100).color).toBe('#6d28d9');
+  });
+
+  test('30-59 returns amber style', () => {
+    const style = getMatchScoreBadgeStyles(30);
+    expect(style.backgroundColor).toBe('#fffbeb');
+    expect(style.color).toBe('#b45309');
+    expect(style.border).toContain('#fcd34d');
+  });
+
+  test('59 returns amber (boundary)', () => {
+    expect(getMatchScoreBadgeStyles(59).color).toBe('#b45309');
+  });
+
+  test('<30 returns neutral style', () => {
+    const style = getMatchScoreBadgeStyles(0);
+    expect(style.backgroundColor).toBe('#f9fafb');
+    expect(style.color).toBe('#6b7280');
+    expect(style.border).toContain('#d1d5db');
+  });
+
+  test('29 is neutral, 30 is amber (boundary)', () => {
+    expect(getMatchScoreBadgeStyles(29).color).toBe('#6b7280');
+    expect(getMatchScoreBadgeStyles(30).color).toBe('#b45309');
+  });
+
+  test('always returns object with 3 keys', () => {
+    [0, 15, 29, 30, 59, 60, 100].forEach(score => {
+      const style = getMatchScoreBadgeStyles(score);
+      expect(style).toHaveProperty('backgroundColor');
+      expect(style).toHaveProperty('color');
+      expect(style).toHaveProperty('border');
+    });
+  });
+});
+
+describe('getFundingGroupDotColor', () => {
+  test('grants returns emerald hex', () => {
+    expect(getFundingGroupDotColor('grants')).toBe('#10b981');
+  });
+
+  test('incentives returns violet hex', () => {
+    expect(getFundingGroupDotColor('incentives')).toBe('#8b5cf6');
+  });
+
+  test('tax returns amber hex', () => {
+    expect(getFundingGroupDotColor('tax')).toBe('#f59e0b');
+  });
+
+  test('loans returns blue hex', () => {
+    expect(getFundingGroupDotColor('loans')).toBe('#3b82f6');
+  });
+
+  test('other returns neutral hex', () => {
+    expect(getFundingGroupDotColor('other')).toBe('#a3a3a3');
+  });
+
+  test('unknown key returns other color', () => {
+    expect(getFundingGroupDotColor('unknown')).toBe('#a3a3a3');
+  });
+});
+
+describe('formatBudgetDisplay', () => {
+  test('label key returns human-readable label', () => {
+    expect(formatBudgetDisplay('small')).toBe('Small ($50K - $500K)');
+    expect(formatBudgetDisplay('medium')).toBe('Medium ($500K - $5M)');
+    expect(formatBudgetDisplay('large')).toBe('Large ($5M - $50M)');
+    expect(formatBudgetDisplay('very_large')).toBe('Very Large ($50M+)');
+  });
+
+  test('numeric budget is formatted with commas', () => {
+    expect(formatBudgetDisplay(30000000)).toBe('$30,000,000');
+    expect(formatBudgetDisplay(500000)).toBe('$500,000');
+    expect(formatBudgetDisplay(0)).toBe('$0');
+  });
+
+  test('string numeric budget is formatted', () => {
+    expect(formatBudgetDisplay('30000000')).toBe('$30,000,000');
+    expect(formatBudgetDisplay('500000')).toBe('$500,000');
+  });
+
+  test('non-numeric string passes through', () => {
+    expect(formatBudgetDisplay('custom budget')).toBe('custom budget');
+  });
+
+  test('null/undefined returns "Not specified"', () => {
+    expect(formatBudgetDisplay(null)).toBe('Not specified');
+    expect(formatBudgetDisplay(undefined)).toBe('Not specified');
+  });
+
+  test('empty string returns "Not specified"', () => {
+    expect(formatBudgetDisplay('')).toBe('Not specified');
+  });
+});


### PR DESCRIPTION
## Summary
- Redesign `/clients/[clientId]/matches` page: group matches by funding type (Grants → Tax → Loans → Incentives → Other) with colored section headers and relevance-based sorting within groups
- Merge Project Needs + Match Breakdown into a single section with inline match counts per need
- Add context strip above each card (match % badge + hide button), restore native status badges
- Centralize `FUNDING_TYPE_GROUPS` constant in `taxonomies.js` for reuse on future views (e.g., opportunity explorer)
- Adjust taxonomy scoring tiers per domain review: Voucher → strong, Rebate → mild, Cooperative Agreement → strong
- Fix empty string budget bug and Tailwind JIT class purging issues

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 1214 critical tests pass (`npm run test:critical`)
- [x] All 490 pipeline tests pass (`npm run test:pipeline`)
- [x] 35 new tests cover all added utility functions
- [x] Visual verification in browser — cards render with blue accent bars, grouped sections, context strips
- [ ] Verify on staging after merge

Relates to #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)