### PR TITLE
Match persistence, card redesign, and match detail page

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "autoPort": true
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,12 @@ next-env.d.ts
 # supabase
 supabase/.temp/
 
+# Claude Code worktrees
+.claude/worktrees/
+
+# Playwright MCP
+.playwright-mcp/
+
 # temp working files (discovery data, etc.)
 temp/
 

--- a/app/api/client-matching/route.js
+++ b/app/api/client-matching/route.js
@@ -1,159 +1,49 @@
 /**
  * Client-Opportunity Matching API
  *
- * Matches clients from the database against real opportunities
- * Returns match scores based on location, applicant type, project needs, and activities
+ * Reads pre-computed matches from the client_matches table (populated by
+ * the background match computation job). JOINs funding_opportunities for
+ * full opportunity details.
  *
- * Location matching uses coverage_area_ids for precise geographic matching:
- * - Utility-level precision (e.g., PG&E vs SCE)
- * - County-level precision (e.g., Marin County)
- * - State-level matching
- * - National opportunities match all clients
+ * Much faster than the previous approach which recomputed matches from
+ * scratch on every request using O(n*m) evaluateMatch() calls.
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
-import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
   process.env.SUPABASE_SECRET_KEY
 );
 
+/**
+ * Transform a raw client_matches row (with joined opportunity) into the
+ * response shape the frontend expects.
+ */
+function transformMatch(row) {
+  const opp = row.opportunity;
+  return {
+    ...opp,
+    source_type: opp.funding_sources?.type || null,
+    funding_sources: undefined,
+    score: row.score,
+    matchDetails: row.match_details,
+    is_new: row.is_new,
+    first_matched_at: row.first_matched_at
+  };
+}
+
 export async function GET(request) {
   try {
     const { searchParams } = new URL(request.url);
     const clientId = searchParams.get('clientId');
 
-    console.log(`[ClientMatching] Starting matching process${clientId ? ` for client: ${clientId}` : ' for all clients'}`);
-
-    // Get clients from database
-    let clientQuery = supabase.from('clients').select('*');
+    console.log(`[ClientMatching] Reading persisted matches${clientId ? ` for client: ${clientId}` : ' for all clients'}`);
 
     if (clientId) {
-      clientQuery = clientQuery.eq('id', clientId);
+      return handleSingleClient(clientId);
     }
-
-    const { data: clientsToProcess, error: clientError } = await clientQuery;
-
-    if (clientError) {
-      console.error('[ClientMatching] Error fetching clients:', clientError);
-      return Response.json({ error: 'Failed to fetch clients' }, { status: 500 });
-    }
-
-    if (!clientsToProcess || clientsToProcess.length === 0) {
-      return Response.json({ error: 'Client not found' }, { status: 404 });
-    }
-
-    // Get all open opportunities with source type from funding_sources (exclude closed)
-    const { data: rawOpportunities, error } = await supabase
-      .from('funding_opportunities')
-      .select(`
-        id, title, eligible_locations, eligible_applicants,
-        eligible_project_types, eligible_activities, is_national,
-        minimum_award, maximum_award, total_funding_available,
-        close_date, agency_name, categories, relevance_score,
-        status, created_at, program_overview, program_insights,
-        funding_sources(type)
-      `)
-      .neq('status', 'closed')
-      .or('promotion_status.is.null,promotion_status.eq.promoted');
-
-    if (error) {
-      console.error('[ClientMatching] Database error:', error);
-      return Response.json({ error: 'Failed to fetch opportunities' }, { status: 500 });
-    }
-
-    // Flatten funding_sources.type to source_type on each opportunity
-    const opportunities = (rawOpportunities || []).map(opp => ({
-      ...opp,
-      source_type: opp.funding_sources?.type || null,
-      funding_sources: undefined // Remove nested object
-    }));
-
-    // Get opportunity coverage areas separately (since we need to join)
-    const { data: opportunityCoverageAreas, error: coverageError } = await supabase
-      .from('opportunity_coverage_areas')
-      .select('opportunity_id, coverage_area_id');
-
-    if (coverageError) {
-      console.error('[ClientMatching] Error fetching coverage areas:', coverageError);
-      return Response.json({ error: 'Failed to fetch opportunity coverage areas' }, { status: 500 });
-    }
-
-    // Build lookup map: opportunityId -> coverageAreaIds[]
-    const opportunityCoverageMap = {};
-    for (const link of opportunityCoverageAreas || []) {
-      if (!opportunityCoverageMap[link.opportunity_id]) {
-        opportunityCoverageMap[link.opportunity_id] = [];
-      }
-      opportunityCoverageMap[link.opportunity_id].push(link.coverage_area_id);
-    }
-
-    // Attach coverage area IDs to each opportunity
-    for (const opp of opportunities) {
-      opp.coverage_area_ids = opportunityCoverageMap[opp.id] || [];
-    }
-
-    console.log(`[ClientMatching] Found ${opportunities.length} opportunities to match against`);
-
-    // Batch-fetch all hidden matches in a single query (eliminates N+1 pattern)
-    const { data: allHiddenMatches, error: hiddenError } = await supabase
-      .from('hidden_matches')
-      .select('client_id, opportunity_id');
-
-    if (hiddenError) {
-      console.error('[ClientMatching] Error fetching hidden matches:', hiddenError);
-    }
-
-    const hiddenMap = new Map();
-    for (const h of allHiddenMatches || []) {
-      if (!hiddenMap.has(h.client_id)) hiddenMap.set(h.client_id, new Set());
-      hiddenMap.get(h.client_id).add(h.opportunity_id);
-    }
-
-    // Calculate matches for each client
-    const results = {};
-
-    for (const client of clientsToProcess) {
-      console.log(`[ClientMatching] Processing client: ${client.name}`);
-      console.log(`[ClientMatching] Client details:`, {
-        type: client.type,
-        project_needs: client.project_needs,
-        coverage_area_count: client.coverage_area_ids?.length || 0,
-        city: client.city,
-        state_code: client.state_code
-      });
-
-      const hiddenOpportunityIds = hiddenMap.get(client.id) || new Set();
-      const hiddenCount = hiddenOpportunityIds.size;
-
-      // Filter out hidden opportunities before matching
-      const visibleOpportunities = opportunities.filter(opp => !hiddenOpportunityIds.has(opp.id));
-
-      if (hiddenCount > 0) {
-        console.log(`[ClientMatching] Filtered out ${hiddenCount} hidden matches for ${client.name}`);
-      }
-
-      const matches = calculateMatches(client, visibleOpportunities);
-
-      results[client.id] = {
-        client,
-        matches: matches.sort((a, b) => b.score - a.score), // Sort by score descending
-        matchCount: matches.length,
-        hiddenCount, // Include hidden count in response
-        topMatches: matches.slice(0, 3) // Top 3 for card display
-      };
-
-      console.log(`[ClientMatching] Found ${matches.length} matches for ${client.name}`);
-    }
-
-    return Response.json({
-      success: true,
-      results: clientId ? results[clientId] : results,
-      timestamp: new Date().toISOString()
-    });
-
+    return handleAllClients();
   } catch (error) {
     console.error('[ClientMatching] API error:', error);
     return Response.json({
@@ -164,26 +54,161 @@ export async function GET(request) {
 }
 
 /**
- * Calculate matches between a client and opportunities
+ * Single-client mode: returns matches for one client.
  */
-function calculateMatches(client, opportunities) {
-  const matches = [];
-  const deps = {
-    hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
-    getExpandedClientTypes
-  };
+async function handleSingleClient(clientId) {
+  // 1. Fetch the client
+  const { data: client, error: clientError } = await supabase
+    .from('clients')
+    .select('*')
+    .eq('id', clientId)
+    .single();
 
-  for (const opportunity of opportunities) {
-    const matchResult = evaluateMatch(client, opportunity, deps);
-
-    if (matchResult.isMatch) {
-      matches.push({
-        ...opportunity,
-        score: matchResult.score,
-        matchDetails: matchResult.details
-      });
-    }
+  if (clientError || !client) {
+    console.error('[ClientMatching] Error fetching client:', clientError);
+    return Response.json({ error: 'Client not found' }, { status: 404 });
   }
 
-  return matches;
+  // 2. Fetch hidden opportunity IDs for this client
+  const { data: hiddenRows, error: hiddenError } = await supabase
+    .from('hidden_matches')
+    .select('opportunity_id')
+    .eq('client_id', clientId)
+    .limit(10000);
+
+  if (hiddenError) {
+    console.error('[ClientMatching] Error fetching hidden matches:', hiddenError);
+  }
+
+  const hiddenIds = new Set((hiddenRows || []).map(h => h.opportunity_id));
+
+  // 3. Query persisted matches with opportunity details
+  const { data: matchRows, error: matchError } = await supabase
+    .from('client_matches')
+    .select(`
+      score, match_details, is_new, first_matched_at,
+      opportunity:funding_opportunities!inner(
+        *, funding_sources(type)
+      )
+    `)
+    .eq('client_id', clientId)
+    .eq('is_stale', false)
+    .limit(10000);
+
+  if (matchError) {
+    console.error('[ClientMatching] Error fetching matches:', matchError);
+    return Response.json({ error: 'Failed to fetch matches' }, { status: 500 });
+  }
+
+  // 4. Filter hidden and transform
+  const matches = (matchRows || [])
+    .filter(row => !hiddenIds.has(row.opportunity.id))
+    .map(transformMatch)
+    .sort((a, b) => b.score - a.score);
+
+  const result = {
+    client,
+    matches,
+    matchCount: matches.length,
+    hiddenCount: hiddenIds.size,
+    topMatches: matches.slice(0, 3)
+  };
+
+  console.log(`[ClientMatching] Found ${matches.length} matches for ${client.name}`);
+
+  return Response.json({
+    success: true,
+    results: result,
+    timestamp: new Date().toISOString()
+  });
+}
+
+/**
+ * All-clients mode: returns matches grouped by client.
+ */
+async function handleAllClients() {
+  // 1. Fetch all clients
+  const { data: clients, error: clientError } = await supabase
+    .from('clients')
+    .select('*');
+
+  if (clientError) {
+    console.error('[ClientMatching] Error fetching clients:', clientError);
+    return Response.json({ error: 'Failed to fetch clients' }, { status: 500 });
+  }
+
+  if (!clients || clients.length === 0) {
+    return Response.json({ error: 'No clients found' }, { status: 404 });
+  }
+
+  // 2. Fetch all non-stale matches with opportunity details
+  const { data: matchRows, error: matchError } = await supabase
+    .from('client_matches')
+    .select(`
+      client_id, score, match_details, is_new, first_matched_at,
+      opportunity:funding_opportunities!inner(
+        *, funding_sources(type)
+      )
+    `)
+    .eq('is_stale', false)
+    .limit(10000);
+
+  if (matchError) {
+    console.error('[ClientMatching] Error fetching matches:', matchError);
+    return Response.json({ error: 'Failed to fetch matches' }, { status: 500 });
+  }
+
+  // 3. Batch-fetch all hidden matches
+  const { data: allHiddenMatches, error: hiddenError } = await supabase
+    .from('hidden_matches')
+    .select('client_id, opportunity_id')
+    .limit(10000);
+
+  if (hiddenError) {
+    console.error('[ClientMatching] Error fetching hidden matches:', hiddenError);
+  }
+
+  const hiddenMap = new Map();
+  for (const h of allHiddenMatches || []) {
+    if (!hiddenMap.has(h.client_id)) hiddenMap.set(h.client_id, new Set());
+    hiddenMap.get(h.client_id).add(h.opportunity_id);
+  }
+
+  // 4. Group matches by client, filter hidden, transform
+  const matchesByClient = new Map();
+  for (const row of matchRows || []) {
+    const cid = row.client_id;
+    const hiddenIds = hiddenMap.get(cid);
+    if (hiddenIds && hiddenIds.has(row.opportunity.id)) continue;
+
+    if (!matchesByClient.has(cid)) matchesByClient.set(cid, []);
+    matchesByClient.get(cid).push(transformMatch(row));
+  }
+
+  // 5. Build results keyed by client ID
+  const results = {};
+
+  for (const client of clients) {
+    const clientMatches = matchesByClient.get(client.id) || [];
+    clientMatches.sort((a, b) => b.score - a.score);
+
+    const hiddenIds = hiddenMap.get(client.id);
+    const hiddenCount = hiddenIds ? hiddenIds.size : 0;
+
+    results[client.id] = {
+      client,
+      matches: clientMatches,
+      matchCount: clientMatches.length,
+      hiddenCount,
+      topMatches: clientMatches.slice(0, 3)
+    };
+  }
+
+  console.log(`[ClientMatching] Returned matches for ${clients.length} clients`);
+
+  return Response.json({
+    success: true,
+    results,
+    timestamp: new Date().toISOString()
+  });
 }

--- a/app/api/client-matching/route.js
+++ b/app/api/client-matching/route.js
@@ -97,6 +97,21 @@ export async function GET(request) {
 
     console.log(`[ClientMatching] Found ${opportunities.length} opportunities to match against`);
 
+    // Batch-fetch all hidden matches in a single query (eliminates N+1 pattern)
+    const { data: allHiddenMatches, error: hiddenError } = await supabase
+      .from('hidden_matches')
+      .select('client_id, opportunity_id');
+
+    if (hiddenError) {
+      console.error('[ClientMatching] Error fetching hidden matches:', hiddenError);
+    }
+
+    const hiddenMap = new Map();
+    for (const h of allHiddenMatches || []) {
+      if (!hiddenMap.has(h.client_id)) hiddenMap.set(h.client_id, new Set());
+      hiddenMap.get(h.client_id).add(h.opportunity_id);
+    }
+
     // Calculate matches for each client
     const results = {};
 
@@ -110,17 +125,7 @@ export async function GET(request) {
         state_code: client.state_code
       });
 
-      // Fetch hidden matches for this client
-      const { data: hiddenMatches, error: hiddenError } = await supabase
-        .from('hidden_matches')
-        .select('opportunity_id')
-        .eq('client_id', client.id);
-
-      if (hiddenError) {
-        console.error('[ClientMatching] Error fetching hidden matches:', hiddenError);
-      }
-
-      const hiddenOpportunityIds = new Set((hiddenMatches || []).map(h => h.opportunity_id));
+      const hiddenOpportunityIds = hiddenMap.get(client.id) || new Set();
       const hiddenCount = hiddenOpportunityIds.size;
 
       // Filter out hidden opportunities before matching

--- a/app/api/client-matching/route.js
+++ b/app/api/client-matching/route.js
@@ -13,23 +13,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
-
-/**
- * Normalize a type string for matching comparison.
- * Handles plurals, case, and common variations.
- *
- * @param {string} type - The type string to normalize
- * @returns {string} Normalized type string
- */
-function normalizeType(type) {
-  if (!type) return '';
-  return type
-    .toLowerCase()
-    .trim()
-    .replace(/ies$/, 'y')           // agencies → agency, utilities → utility
-    .replace(/(ch|sh|ss|x|z)es$/, '$1')  // churches → church, businesses → business (only after ch/sh/ss/x/z)
-    .replace(/s$/, '');             // hospitals → hospital, colleges → college, governments → government
-}
+import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -179,9 +163,13 @@ export async function GET(request) {
  */
 function calculateMatches(client, opportunities) {
   const matches = [];
+  const deps = {
+    hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
+    getExpandedClientTypes
+  };
 
   for (const opportunity of opportunities) {
-    const matchResult = evaluateMatch(client, opportunity);
+    const matchResult = evaluateMatch(client, opportunity, deps);
 
     if (matchResult.isMatch) {
       matches.push({
@@ -193,99 +181,4 @@ function calculateMatches(client, opportunities) {
   }
 
   return matches;
-}
-
-/**
- * Evaluate if an opportunity matches a client
- */
-function evaluateMatch(client, opportunity) {
-  const details = {
-    locationMatch: false,
-    applicantTypeMatch: false,
-    projectNeedsMatch: false,
-    activitiesMatch: false,
-    matchedProjectNeeds: []
-  };
-
-  // 1. Location Match (using coverage_area_ids for precise geographic matching)
-  if (opportunity.is_national) {
-    // National opportunities match all clients
-    details.locationMatch = true;
-  } else if (client.coverage_area_ids && Array.isArray(client.coverage_area_ids) &&
-             opportunity.coverage_area_ids && Array.isArray(opportunity.coverage_area_ids)) {
-    // Check if client's coverage areas intersect with opportunity's coverage areas
-    // This provides utility-level, county-level, or state-level precision
-    const hasIntersection = client.coverage_area_ids.some(clientAreaId =>
-      opportunity.coverage_area_ids.includes(clientAreaId)
-    );
-    details.locationMatch = hasIntersection;
-  }
-
-  // 2. Applicant Type Match (with synonym + hierarchy expansion)
-  if (opportunity.eligible_applicants && Array.isArray(opportunity.eligible_applicants)) {
-    // Get expanded types for this client (synonyms + child → parent expansion)
-    // e.g., "Municipal Government" expands to ["Municipal Government", "City Government", "Township Government", "Local Governments"]
-    const expandedTypes = getExpandedClientTypes(client.type);
-
-    // Check if any expanded type matches any eligible applicant
-    // Uses normalization for plural/case tolerance
-    details.applicantTypeMatch = opportunity.eligible_applicants.some(applicant => {
-      const normalizedApplicant = normalizeType(applicant);
-      return expandedTypes.some(clientType => {
-        const normalizedClient = normalizeType(clientType);
-        return (
-          normalizedApplicant === normalizedClient ||
-          normalizedApplicant.includes(normalizedClient) ||
-          normalizedClient.includes(normalizedApplicant)
-        );
-      });
-    });
-  }
-
-  // 3. Project Needs Match
-  if (opportunity.eligible_project_types && Array.isArray(opportunity.eligible_project_types) &&
-      client.project_needs && Array.isArray(client.project_needs)) {
-
-    for (const need of client.project_needs) {
-      const hasMatch = opportunity.eligible_project_types.some(projectType =>
-        projectType.toLowerCase().includes(need.toLowerCase()) ||
-        need.toLowerCase().includes(projectType.toLowerCase())
-      );
-
-      if (hasMatch) {
-        details.matchedProjectNeeds.push(need);
-      }
-    }
-
-    details.projectNeedsMatch = details.matchedProjectNeeds.length > 0;
-  }
-
-  // 4. Activities Match (must include "hot" activities for construction/implementation)
-  if (opportunity.eligible_activities && Array.isArray(opportunity.eligible_activities)) {
-    const hotActivities = TAXONOMIES.ELIGIBLE_ACTIVITIES.hot;
-    details.activitiesMatch = opportunity.eligible_activities.some(activity =>
-      hotActivities.some(hotActivity =>
-        activity.toLowerCase().includes(hotActivity.toLowerCase()) ||
-        hotActivity.toLowerCase().includes(activity.toLowerCase())
-      )
-    );
-  }
-
-  // Check if all criteria are met
-  const isMatch = details.locationMatch &&
-                  details.applicantTypeMatch &&
-                  details.projectNeedsMatch &&
-                  details.activitiesMatch;
-
-  // Calculate score (% of project needs matched)
-  let score = 0;
-  if (isMatch && client.project_needs && client.project_needs.length > 0) {
-    score = Math.round((details.matchedProjectNeeds.length / client.project_needs.length) * 100);
-  }
-
-  return {
-    isMatch,
-    score,
-    details
-  };
 }

--- a/app/api/client-matching/summary/route.js
+++ b/app/api/client-matching/summary/route.js
@@ -2,14 +2,14 @@
  * Client Matching Summary API
  *
  * Returns client matching statistics for dashboard display:
- * - clientsWithMatches: number of clients that have at least 1 match
- * - totalMatches: sum of all matches across all clients
+ * - clientsWithMatches: number of clients that have at least 1 visible match
+ * - totalMatches: sum of all visible matches across all clients
  * - totalClients: total number of clients in system
+ *
+ * Reads from persisted client_matches table instead of recomputing.
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
-import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
 	process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -36,91 +36,73 @@ export async function GET() {
 			});
 		}
 
-		console.log('[ClientMatchingSummary] Calculating match statistics');
+		console.log('[ClientMatchingSummary] Calculating match statistics from client_matches');
 
-		// Get all clients from database
-		const { data: clients, error: clientError } = await supabase
+		// 1. Count total clients
+		const { count: totalClients, error: clientError } = await supabase
 			.from('clients')
-			.select('*');
+			.select('*', { count: 'exact', head: true });
 
 		if (clientError) {
-			console.error('[ClientMatchingSummary] Error fetching clients:', clientError);
+			console.error('[ClientMatchingSummary] Error counting clients:', clientError);
 			return Response.json(
-				{ success: false, error: 'Failed to fetch clients' },
+				{ success: false, error: 'Failed to count clients' },
 				{ status: 500 }
 			);
 		}
 
-		const totalClients = clients?.length || 0;
+		// 2. Fetch all non-stale match pairs
+		const { data: matchRows, error: matchError } = await supabase
+			.from('client_matches')
+			.select('client_id, opportunity_id')
+			.eq('is_stale', false)
+			.limit(10000);
 
-		// Get all open opportunities
-		const { data: rawOpportunities, error: oppError } = await supabase
-			.from('funding_opportunities')
-			.select(
-				`
-				id, title, eligible_locations, eligible_applicants,
-				eligible_project_types, eligible_activities, is_national,
-				status
-			`
-			)
-			.neq('status', 'closed')
-			.or('promotion_status.is.null,promotion_status.eq.promoted');
-
-		if (oppError) {
-			console.error('[ClientMatchingSummary] Error fetching opportunities:', oppError);
+		if (matchError) {
+			console.error('[ClientMatchingSummary] Error fetching matches:', matchError);
 			return Response.json(
-				{ success: false, error: 'Failed to fetch opportunities' },
+				{ success: false, error: 'Failed to fetch matches' },
 				{ status: 500 }
 			);
 		}
 
-		// Get opportunity coverage areas
-		const { data: opportunityCoverageAreas, error: coverageError } = await supabase
-			.from('opportunity_coverage_areas')
-			.select('opportunity_id, coverage_area_id');
+		// 3. Fetch hidden matches to exclude
+		const { data: hiddenRows, error: hiddenError } = await supabase
+			.from('hidden_matches')
+			.select('client_id, opportunity_id')
+			.limit(10000);
 
-		if (coverageError) {
-			console.error('[ClientMatchingSummary] Error fetching coverage areas:', coverageError);
+		if (hiddenError) {
+			console.error('[ClientMatchingSummary] Error fetching hidden matches:', hiddenError);
 		}
 
-		// Build coverage map
-		const opportunityCoverageMap = {};
-		for (const link of opportunityCoverageAreas || []) {
-			if (!opportunityCoverageMap[link.opportunity_id]) {
-				opportunityCoverageMap[link.opportunity_id] = [];
-			}
-			opportunityCoverageMap[link.opportunity_id].push(link.coverage_area_id);
-		}
+		const hiddenSet = new Set(
+			(hiddenRows || []).map(h => `${h.client_id}:${h.opportunity_id}`)
+		);
 
-		// Attach coverage areas to opportunities
-		const opportunities = (rawOpportunities || []).map((opp) => ({
-			...opp,
-			coverage_area_ids: opportunityCoverageMap[opp.id] || [],
-		}));
-
-		// Calculate matches for each client
-		let clientsWithMatches = 0;
+		// 4. Filter visible matches and compute stats
+		const clientsWithMatchesSet = new Set();
 		let totalMatches = 0;
 
-		for (const client of clients || []) {
-			const matchCount = countMatches(client, opportunities);
-			if (matchCount > 0) {
-				clientsWithMatches++;
-				totalMatches += matchCount;
-			}
+		for (const row of matchRows || []) {
+			const key = `${row.client_id}:${row.opportunity_id}`;
+			if (hiddenSet.has(key)) continue;
+			clientsWithMatchesSet.add(row.client_id);
+			totalMatches++;
 		}
 
-		// Cache the result
 		const result = {
-			clientsWithMatches,
+			clientsWithMatches: clientsWithMatchesSet.size,
 			totalMatches,
-			totalClients,
+			totalClients: totalClients || 0,
 		};
+
+		// Cache the result
 		cache.data = result;
 		cache.timestamp = now;
 
 		console.log(
-			`[ClientMatchingSummary] ${clientsWithMatches}/${totalClients} clients with matches, ${totalMatches} total`
+			`[ClientMatchingSummary] ${result.clientsWithMatches}/${result.totalClients} clients with matches, ${totalMatches} total`
 		);
 
 		return Response.json({
@@ -140,24 +122,4 @@ export async function GET() {
 			{ status: 500 }
 		);
 	}
-}
-
-/**
- * Count matches between a client and opportunities
- */
-function countMatches(client, opportunities) {
-	let count = 0;
-	const deps = {
-		hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
-		getExpandedClientTypes
-	};
-
-	for (const opportunity of opportunities) {
-		const result = evaluateMatch(client, opportunity, deps);
-		if (result.isMatch) {
-			count++;
-		}
-	}
-
-	return count;
 }

--- a/app/api/client-matching/summary/route.js
+++ b/app/api/client-matching/summary/route.js
@@ -9,6 +9,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
+import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
 	process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -146,90 +147,17 @@ export async function GET() {
  */
 function countMatches(client, opportunities) {
 	let count = 0;
+	const deps = {
+		hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
+		getExpandedClientTypes
+	};
 
 	for (const opportunity of opportunities) {
-		if (evaluateMatch(client, opportunity)) {
+		const result = evaluateMatch(client, opportunity, deps);
+		if (result.isMatch) {
 			count++;
 		}
 	}
 
 	return count;
-}
-
-/**
- * Evaluate if an opportunity matches a client
- * Uses same logic as top-matches API for consistency
- */
-function evaluateMatch(client, opportunity) {
-	// 1. Location Match
-	let locationMatch = false;
-	if (opportunity.is_national) {
-		locationMatch = true;
-	} else if (
-		client.coverage_area_ids &&
-		Array.isArray(client.coverage_area_ids) &&
-		opportunity.coverage_area_ids &&
-		Array.isArray(opportunity.coverage_area_ids)
-	) {
-		locationMatch = client.coverage_area_ids.some((clientAreaId) =>
-			opportunity.coverage_area_ids.includes(clientAreaId)
-		);
-	}
-
-	if (!locationMatch) return false;
-
-	// 2. Applicant Type Match
-	let applicantTypeMatch = false;
-	if (opportunity.eligible_applicants && Array.isArray(opportunity.eligible_applicants)) {
-		const expandedTypes = getExpandedClientTypes(client.type);
-		applicantTypeMatch = opportunity.eligible_applicants.some((applicant) =>
-			expandedTypes.some(
-				(clientType) =>
-					applicant.toLowerCase() === clientType.toLowerCase() ||
-					applicant.toLowerCase().includes(clientType.toLowerCase()) ||
-					clientType.toLowerCase().includes(applicant.toLowerCase())
-			)
-		);
-	}
-
-	if (!applicantTypeMatch) return false;
-
-	// 3. Project Needs Match
-	let projectNeedsMatch = false;
-	if (
-		opportunity.eligible_project_types &&
-		Array.isArray(opportunity.eligible_project_types) &&
-		client.project_needs &&
-		Array.isArray(client.project_needs)
-	) {
-		for (const need of client.project_needs) {
-			const hasMatch = opportunity.eligible_project_types.some(
-				(projectType) =>
-					projectType.toLowerCase().includes(need.toLowerCase()) ||
-					need.toLowerCase().includes(projectType.toLowerCase())
-			);
-
-			if (hasMatch) {
-				projectNeedsMatch = true;
-				break;
-			}
-		}
-	}
-
-	if (!projectNeedsMatch) return false;
-
-	// 4. Activities Match
-	let activitiesMatch = false;
-	if (opportunity.eligible_activities && Array.isArray(opportunity.eligible_activities)) {
-		const hotActivities = TAXONOMIES.ELIGIBLE_ACTIVITIES.hot;
-		activitiesMatch = opportunity.eligible_activities.some((activity) =>
-			hotActivities.some(
-				(hotActivity) =>
-					activity.toLowerCase().includes(hotActivity.toLowerCase()) ||
-					hotActivity.toLowerCase().includes(activity.toLowerCase())
-			)
-		);
-	}
-
-	return activitiesMatch;
 }

--- a/app/api/client-matching/top-matches/route.js
+++ b/app/api/client-matching/top-matches/route.js
@@ -7,6 +7,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
+import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
 	process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -155,9 +156,13 @@ export async function GET() {
  */
 function calculateMatches(client, opportunities) {
 	const matches = [];
+	const deps = {
+		hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
+		getExpandedClientTypes
+	};
 
 	for (const opportunity of opportunities) {
-		const matchResult = evaluateMatch(client, opportunity);
+		const matchResult = evaluateMatch(client, opportunity, deps);
 
 		if (matchResult.isMatch) {
 			matches.push({
@@ -169,100 +174,4 @@ function calculateMatches(client, opportunities) {
 
 	// Sort by score descending
 	return matches.sort((a, b) => b.score - a.score);
-}
-
-/**
- * Evaluate if an opportunity matches a client
- */
-function evaluateMatch(client, opportunity) {
-	const details = {
-		locationMatch: false,
-		applicantTypeMatch: false,
-		projectNeedsMatch: false,
-		activitiesMatch: false,
-		matchedProjectNeeds: [],
-	};
-
-	// 1. Location Match
-	if (opportunity.is_national) {
-		details.locationMatch = true;
-	} else if (
-		client.coverage_area_ids &&
-		Array.isArray(client.coverage_area_ids) &&
-		opportunity.coverage_area_ids &&
-		Array.isArray(opportunity.coverage_area_ids)
-	) {
-		const hasIntersection = client.coverage_area_ids.some((clientAreaId) =>
-			opportunity.coverage_area_ids.includes(clientAreaId)
-		);
-		details.locationMatch = hasIntersection;
-	}
-
-	// 2. Applicant Type Match
-	if (opportunity.eligible_applicants && Array.isArray(opportunity.eligible_applicants)) {
-		const expandedTypes = getExpandedClientTypes(client.type);
-		details.applicantTypeMatch = opportunity.eligible_applicants.some((applicant) =>
-			expandedTypes.some(
-				(clientType) =>
-					applicant.toLowerCase() === clientType.toLowerCase() ||
-					applicant.toLowerCase().includes(clientType.toLowerCase()) ||
-					clientType.toLowerCase().includes(applicant.toLowerCase())
-			)
-		);
-	}
-
-	// 3. Project Needs Match
-	if (
-		opportunity.eligible_project_types &&
-		Array.isArray(opportunity.eligible_project_types) &&
-		client.project_needs &&
-		Array.isArray(client.project_needs)
-	) {
-		for (const need of client.project_needs) {
-			const hasMatch = opportunity.eligible_project_types.some(
-				(projectType) =>
-					projectType.toLowerCase().includes(need.toLowerCase()) ||
-					need.toLowerCase().includes(projectType.toLowerCase())
-			);
-
-			if (hasMatch) {
-				details.matchedProjectNeeds.push(need);
-			}
-		}
-
-		details.projectNeedsMatch = details.matchedProjectNeeds.length > 0;
-	}
-
-	// 4. Activities Match
-	if (opportunity.eligible_activities && Array.isArray(opportunity.eligible_activities)) {
-		const hotActivities = TAXONOMIES.ELIGIBLE_ACTIVITIES.hot;
-		details.activitiesMatch = opportunity.eligible_activities.some((activity) =>
-			hotActivities.some(
-				(hotActivity) =>
-					activity.toLowerCase().includes(hotActivity.toLowerCase()) ||
-					hotActivity.toLowerCase().includes(activity.toLowerCase())
-			)
-		);
-	}
-
-	// Check if all criteria are met
-	const isMatch =
-		details.locationMatch &&
-		details.applicantTypeMatch &&
-		details.projectNeedsMatch &&
-		details.activitiesMatch;
-
-	// Calculate score (% of project needs matched)
-	let score = 0;
-	if (isMatch && client.project_needs && client.project_needs.length > 0) {
-		score = Math.round(
-			(details.matchedProjectNeeds.length / client.project_needs.length) * 100
-		);
-	}
-
-	return {
-		isMatch,
-		score,
-		details,
-	};
 }

--- a/app/api/client-matching/top-matches/route.js
+++ b/app/api/client-matching/top-matches/route.js
@@ -3,11 +3,11 @@
  *
  * Returns the top 5 clients with their best opportunity matches for dashboard display.
  * Each result includes the client name, their best matching opportunity, and match score.
+ *
+ * Reads from persisted client_matches table instead of recomputing.
  */
 
 import { createClient } from '@supabase/supabase-js';
-import { TAXONOMIES, getExpandedClientTypes } from '@/lib/constants/taxonomies';
-import { evaluateMatch } from '@/lib/matching/evaluateMatch';
 
 const supabase = createClient(
 	process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -34,88 +34,81 @@ export async function GET() {
 			});
 		}
 
-		console.log('[TopMatches] Calculating top client matches');
+		console.log('[TopMatches] Reading top client matches from client_matches');
 
-		// Get all clients
-		const { data: clients, error: clientError } = await supabase
-			.from('clients')
-			.select('*');
+		// 1. Fetch all non-stale matches with client and opportunity details
+		const { data: matchRows, error: matchError } = await supabase
+			.from('client_matches')
+			.select(`
+				client_id, score, opportunity_id,
+				client:clients!inner(id, name, type),
+				opportunity:funding_opportunities!inner(id, title, maximum_award)
+			`)
+			.eq('is_stale', false)
+			.limit(10000);
 
-		if (clientError) {
-			console.error('[TopMatches] Error fetching clients:', clientError);
+		if (matchError) {
+			console.error('[TopMatches] Error fetching matches:', matchError);
 			return Response.json(
-				{ success: false, error: 'Failed to fetch clients' },
+				{ success: false, error: 'Failed to fetch matches' },
 				{ status: 500 }
 			);
 		}
 
-		// Get all open opportunities
-		const { data: rawOpportunities, error: oppError } = await supabase
-			.from('funding_opportunities')
-			.select(
-				`
-				id, title, eligible_locations, eligible_applicants,
-				eligible_project_types, eligible_activities, is_national,
-				maximum_award, close_date, status
-			`
-			)
-			.neq('status', 'closed')
-			.or('promotion_status.is.null,promotion_status.eq.promoted');
+		// 2. Fetch hidden matches to exclude
+		const { data: hiddenRows, error: hiddenError } = await supabase
+			.from('hidden_matches')
+			.select('client_id, opportunity_id')
+			.limit(10000);
 
-		if (oppError) {
-			console.error('[TopMatches] Error fetching opportunities:', oppError);
-			return Response.json(
-				{ success: false, error: 'Failed to fetch opportunities' },
-				{ status: 500 }
-			);
+		if (hiddenError) {
+			console.error('[TopMatches] Error fetching hidden matches:', hiddenError);
 		}
 
-		// Get opportunity coverage areas
-		const { data: opportunityCoverageAreas, error: coverageError } = await supabase
-			.from('opportunity_coverage_areas')
-			.select('opportunity_id, coverage_area_id');
+		const hiddenSet = new Set(
+			(hiddenRows || []).map(h => `${h.client_id}:${h.opportunity_id}`)
+		);
 
-		if (coverageError) {
-			console.error('[TopMatches] Error fetching coverage areas:', coverageError);
-		}
+		// 3. Group by client, filter hidden
+		const clientMap = {};
+		for (const row of matchRows || []) {
+			const key = `${row.client_id}:${row.opportunity_id}`;
+			if (hiddenSet.has(key)) continue;
 
-		// Build coverage map
-		const opportunityCoverageMap = {};
-		for (const link of opportunityCoverageAreas || []) {
-			if (!opportunityCoverageMap[link.opportunity_id]) {
-				opportunityCoverageMap[link.opportunity_id] = [];
+			const cid = row.client_id;
+			if (!clientMap[cid]) {
+				clientMap[cid] = {
+					client_id: row.client.id,
+					client_name: row.client.name,
+					client_type: row.client.type,
+					matches: [],
+				};
 			}
-			opportunityCoverageMap[link.opportunity_id].push(link.coverage_area_id);
+			clientMap[cid].matches.push({
+				id: row.opportunity.id,
+				title: row.opportunity.title,
+				score: row.score,
+				maximum_award: row.opportunity.maximum_award,
+			});
 		}
 
-		// Attach coverage areas to opportunities
-		const opportunities = (rawOpportunities || []).map((opp) => ({
-			...opp,
-			coverage_area_ids: opportunityCoverageMap[opp.id] || [],
-		}));
+		// 4. Build top-matches list
+		const clientResults = Object.values(clientMap).map(entry => {
+			entry.matches.sort((a, b) => b.score - a.score);
+			const top = entry.matches[0];
+			return {
+				client_id: entry.client_id,
+				client_name: entry.client_name,
+				client_type: entry.client_type,
+				match_count: entry.matches.length,
+				top_opportunity_id: top.id,
+				top_opportunity_title: top.title,
+				top_opportunity_score: top.score,
+				top_opportunity_amount: top.maximum_award,
+			};
+		});
 
-		// Calculate matches for each client
-		const clientResults = [];
-
-		for (const client of clients || []) {
-			const matches = calculateMatches(client, opportunities);
-			const topMatch = matches[0]; // Best match by score
-
-			if (topMatch) {
-				clientResults.push({
-					client_id: client.id,
-					client_name: client.name,
-					client_type: client.type,
-					match_count: matches.length,
-					top_opportunity_id: topMatch.id,
-					top_opportunity_title: topMatch.title,
-					top_opportunity_score: topMatch.score,
-					top_opportunity_amount: topMatch.maximum_award,
-				});
-			}
-		}
-
-		// Sort by match count (clients with most matches first), then by top score
+		// 5. Sort by match count (desc), then top score (desc), take top 5
 		clientResults.sort((a, b) => {
 			if (b.match_count !== a.match_count) {
 				return b.match_count - a.match_count;
@@ -123,7 +116,6 @@ export async function GET() {
 			return b.top_opportunity_score - a.top_opportunity_score;
 		});
 
-		// Take top 5
 		const topMatches = clientResults.slice(0, 5);
 
 		// Cache the result
@@ -149,29 +141,4 @@ export async function GET() {
 			{ status: 500 }
 		);
 	}
-}
-
-/**
- * Calculate matches between a client and opportunities
- */
-function calculateMatches(client, opportunities) {
-	const matches = [];
-	const deps = {
-		hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
-		getExpandedClientTypes
-	};
-
-	for (const opportunity of opportunities) {
-		const matchResult = evaluateMatch(client, opportunity, deps);
-
-		if (matchResult.isMatch) {
-			matches.push({
-				...opportunity,
-				score: matchResult.score,
-			});
-		}
-	}
-
-	// Sort by score descending
-	return matches.sort((a, b) => b.score - a.score);
 }

--- a/app/api/clients/[id]/route.js
+++ b/app/api/clients/[id]/route.js
@@ -9,6 +9,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { geocodeAddress } from '@/lib/services/geocoder';
 import { NextResponse } from 'next/server';
+import { computeMatchesForClient } from '@/lib/matching/computeMatches';
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -179,6 +180,11 @@ export async function PUT(request, { params }) {
     }
 
     console.log(`[API] ✅ Updated client: ${client.id}`);
+
+    // Fire-and-forget: recompute matches for the updated client
+    computeMatchesForClient(supabase, client.id).catch(err =>
+      console.error('[API] Background match computation failed:', err.message)
+    );
 
     return NextResponse.json({
       success: true,

--- a/app/api/clients/route.js
+++ b/app/api/clients/route.js
@@ -8,6 +8,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { geocodeAddress } from '@/lib/services/geocoder';
 import { NextResponse } from 'next/server';
+import { computeMatchesForClient } from '@/lib/matching/computeMatches';
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -246,6 +247,11 @@ export async function POST(request) {
     }
 
     console.log(`[API] ✅ Created client: ${client.id}`);
+
+    // Fire-and-forget: compute matches for the new client
+    computeMatchesForClient(supabase, client.id, { trigger: 'client_created' }).catch(err =>
+      console.error('[API] Background match computation failed:', err.message)
+    );
 
     return NextResponse.json({
       success: true,

--- a/app/api/cron/compute-matches/route.js
+++ b/app/api/cron/compute-matches/route.js
@@ -17,12 +17,18 @@ import {
 } from '../../../../lib/matching/computeMatches.js';
 
 /**
- * Verify the request has a valid Bearer token matching CRON_SECRET.
+ * Verify the request is authorized.
+ * Accepts either:
+ *  1. Bearer token matching CRON_SECRET (Vercel Cron, GitHub Actions, manual triggers)
+ *  2. Dev mode (NODE_ENV !== 'production')
  * Returns null if valid, or a Response if invalid.
  */
 function verifyAuth(request) {
-  const expectedAuth = process.env.CRON_SECRET;
+  // Allow in dev mode
+  if (process.env.NODE_ENV !== 'production') return null;
 
+  // Verify CRON_SECRET — Vercel automatically includes it as Bearer token for cron jobs
+  const expectedAuth = process.env.CRON_SECRET;
   if (!expectedAuth) {
     console.error('[ComputeMatchesCron] CRON_SECRET is not set');
     return Response.json({ error: 'Server misconfigured' }, { status: 500 });

--- a/app/api/cron/compute-matches/route.js
+++ b/app/api/cron/compute-matches/route.js
@@ -1,0 +1,132 @@
+/**
+ * Match Computation Cron Endpoint
+ *
+ * GET  — called by pg_cron daily to recompute all matches
+ * POST — manual trigger for testing, supports scoped computation
+ *
+ * Both handlers require CRON_SECRET auth.
+ *
+ * Endpoint: /api/cron/compute-matches
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import {
+  computeAllMatches,
+  computeMatchesForClient,
+  computeMatchesForOpportunities
+} from '../../../../lib/matching/computeMatches.js';
+
+/**
+ * Verify the request has a valid Bearer token matching CRON_SECRET.
+ * Returns null if valid, or a Response if invalid.
+ */
+function verifyAuth(request) {
+  const expectedAuth = process.env.CRON_SECRET;
+
+  if (!expectedAuth) {
+    console.error('[ComputeMatchesCron] CRON_SECRET is not set');
+    return Response.json({ error: 'Server misconfigured' }, { status: 500 });
+  }
+
+  const authHeader = request.headers.get('authorization');
+  if (authHeader !== `Bearer ${expectedAuth}`) {
+    console.warn('[ComputeMatchesCron] Unauthorized request');
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  return null;
+}
+
+/**
+ * GET /api/cron/compute-matches
+ * Called by pg_cron daily via pg_net.
+ */
+export async function GET(request) {
+  const startTime = Date.now();
+
+  const authError = verifyAuth(request);
+  if (authError) return authError;
+
+  try {
+    console.log(`[ComputeMatchesCron] Daily match computation triggered at ${new Date().toISOString()}`);
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SECRET_KEY
+    );
+
+    const stats = await computeAllMatches(supabase);
+
+    return Response.json({
+      success: true,
+      trigger: 'cron',
+      stats,
+      timestamp: new Date().toISOString(),
+      executionTimeMs: Date.now() - startTime
+    });
+
+  } catch (error) {
+    console.error('[ComputeMatchesCron] Cron failed:', error);
+    return Response.json({
+      success: false,
+      error: error.message,
+      timestamp: new Date().toISOString(),
+      executionTimeMs: Date.now() - startTime
+    }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/cron/compute-matches
+ * Manual trigger for testing. Accepts optional scope.
+ *
+ * Body: { clientId?: string, opportunityIds?: string[] }
+ */
+export async function POST(request) {
+  const startTime = Date.now();
+
+  const authError = verifyAuth(request);
+  if (authError) return authError;
+
+  try {
+    const body = await request.json().catch(() => ({}));
+
+    console.log('[ComputeMatchesCron] Manual trigger:', body);
+
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.SUPABASE_SECRET_KEY
+    );
+
+    let stats;
+    let trigger = 'manual';
+
+    if (body.clientId) {
+      trigger = 'manual_client';
+      stats = await computeMatchesForClient(supabase, body.clientId);
+    } else if (body.opportunityIds?.length) {
+      trigger = 'manual_opportunities';
+      stats = await computeMatchesForOpportunities(supabase, body.opportunityIds);
+    } else {
+      trigger = 'manual_full';
+      stats = await computeAllMatches(supabase);
+    }
+
+    return Response.json({
+      success: true,
+      trigger,
+      stats,
+      timestamp: new Date().toISOString(),
+      executionTimeMs: Date.now() - startTime
+    });
+
+  } catch (error) {
+    console.error('[ComputeMatchesCron] Manual trigger failed:', error);
+    return Response.json({
+      success: false,
+      error: error.message,
+      timestamp: new Date().toISOString(),
+      executionTimeMs: Date.now() - startTime
+    }, { status: 500 });
+  }
+}

--- a/app/api/export/client-matches-pdf/route.js
+++ b/app/api/export/client-matches-pdf/route.js
@@ -15,7 +15,9 @@ const supabase = createClient(
 /**
  * POST /api/export/client-matches-pdf
  *
- * Server-side PDF generation for larger exports
+ * Server-side PDF generation for larger exports.
+ * Reads from persisted client_matches table instead of making
+ * a nested HTTP call to /api/client-matching.
  *
  * Body: {
  *   clientId: string,
@@ -34,7 +36,7 @@ export async function POST(request) {
       return NextResponse.json({ error: 'Client ID is required' }, { status: 400 });
     }
 
-    // Fetch client data
+    // 1. Fetch client data
     const { data: client, error: clientError } = await supabase
       .from('clients')
       .select('*')
@@ -48,37 +50,46 @@ export async function POST(request) {
       );
     }
 
-    // Fetch matches using the existing matching API logic
-    const matchesResponse = await fetch(
-      `${process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'}/api/client-matching?clientId=${clientId}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
+    // 2. Fetch persisted matches with opportunity details
+    const { data: matchRows, error: matchError } = await supabase
+      .from('client_matches')
+      .select(`
+        score, match_details,
+        opportunity:funding_opportunities!inner(*)
+      `)
+      .eq('client_id', clientId)
+      .eq('is_stale', false)
+      .order('score', { ascending: false })
+      .limit(10000);
 
-    if (!matchesResponse.ok) {
+    if (matchError) {
       return NextResponse.json(
         { error: 'Failed to fetch client matches' },
         { status: 500 }
       );
     }
 
-    const matchesData = await matchesResponse.json();
+    // 3. Exclude hidden matches
+    const { data: hiddenRows } = await supabase
+      .from('hidden_matches')
+      .select('opportunity_id')
+      .eq('client_id', clientId)
+      .limit(10000);
 
-    if (!matchesData.success) {
-      return NextResponse.json(
-        { error: matchesData.error || 'Failed to fetch matches' },
-        { status: 500 }
-      );
-    }
+    const hiddenIds = new Set((hiddenRows || []).map(h => h.opportunity_id));
 
-    const matches = matchesData.results?.matches || [];
+    // 4. Transform to shape expected by PDF component
+    const matches = (matchRows || [])
+      .filter(row => !hiddenIds.has(row.opportunity.id))
+      .map(row => ({
+        ...row.opportunity,
+        score: row.score,
+        matchDetails: row.match_details
+      }));
 
-    // Generate PDF
+    // 5. Generate PDF
     const pdfDoc = React.createElement(ClientMatchesPDF, {
-      client: matchesData.results?.client || client,
+      client,
       matches,
       options,
     });

--- a/app/clients/[clientId]/matches/page.jsx
+++ b/app/clients/[clientId]/matches/page.jsx
@@ -6,15 +6,21 @@ import MainLayout from '@/components/layout/main-layout';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { AlertTriangle, Loader2, ArrowLeft, User, MapPin, Building, DollarSign, Target, EyeOff } from 'lucide-react';
+import { AlertTriangle, Loader2, ArrowLeft, MapPin, Building, DollarSign, Target, EyeOff } from 'lucide-react';
 import { ExportPDFButton } from '@/components/clients/ExportPDFButton';
 import { HideMatchButton } from '@/components/clients/HideMatchButton';
 import { HiddenMatchesPanel } from '@/components/clients/HiddenMatchesPanel';
 import Link from 'next/link';
 import OpportunityCard from '@/components/opportunities/OpportunityCard';
-import { fetchClientMatches, formatMatchScore, getMatchScoreBgColor, generateClientTags, formatProjectNeeds } from '@/lib/utils/clientMatching';
+import {
+	fetchClientMatches,
+	formatMatchScore,
+	generateProjectNeedsWithCounts,
+	groupMatchesByFundingType,
+	getMatchScoreBadgeStyles,
+	getFundingGroupDotColor,
+} from '@/lib/utils/clientMatching';
 
 export default function ClientMatchesPage() {
 	const params = useParams();
@@ -46,7 +52,6 @@ export default function ClientMatchesPage() {
 		}
 	}, [clientId, loadClientMatches]);
 
-	// Handler for when a match is hidden
 	const handleMatchHidden = useCallback((opportunityId) => {
 		setClientResult(prev => ({
 			...prev,
@@ -56,9 +61,7 @@ export default function ClientMatchesPage() {
 		setHiddenCount(prev => prev + 1);
 	}, []);
 
-	// Handler for when a match is restored
 	const handleMatchRestored = useCallback(() => {
-		// Refetch matches to get the restored one
 		loadClientMatches();
 	}, [loadClientMatches]);
 
@@ -106,17 +109,34 @@ export default function ClientMatchesPage() {
 	}
 
 	const { client, matches, matchCount } = clientResult;
-	const tags = generateClientTags(client, matches, null); // Show all project needs on detail page
 
-	// Budget labels for display
+	// Merged project needs with match counts
+	const needsWithCounts = generateProjectNeedsWithCounts(client.project_needs, matches);
+
+	// Group matches by funding type, sorted by relevance within each group
+	const groupedMatches = groupMatchesByFundingType(matches);
+
+	// Budget formatting with numeric fallback
 	const budgetLabels = {
 		small: 'Small ($50K - $500K)',
 		medium: 'Medium ($500K - $5M)',
 		large: 'Large ($5M - $50M)',
 		very_large: 'Very Large ($50M+)'
 	};
+	const budgetDisplay = budgetLabels[client.budget]
+		|| (typeof client.budget === 'number'
+			? `$${client.budget.toLocaleString()}`
+			: (typeof client.budget === 'string' && client.budget !== '' && !isNaN(Number(client.budget))
+				? `$${Number(client.budget).toLocaleString()}`
+				: client.budget || 'Not specified'));
 
-	const budgetDisplay = budgetLabels[client.budget] || client.budget || 'Not specified';
+	// Grouped summary for header badge (e.g., "3 Grants, 1 Tax Benefit")
+	const groupedSummary = matchCount === 0
+		? '0 Matches'
+		: groupedMatches.map(g => {
+			const label = g.matches.length === 1 ? g.label.replace(/s$/, '') : g.label;
+			return `${g.matches.length} ${label}`;
+		}).join(', ');
 
 	return (
 		<MainLayout>
@@ -133,91 +153,83 @@ export default function ClientMatchesPage() {
 				</div>
 
 				{/* Client Header */}
-				<div className='mb-8'>
-					<div className='flex items-start justify-between mb-4'>
+				<div className='mb-4'>
+					<div className='flex items-start justify-between mb-3'>
 						<div>
-							<h1 className='text-3xl font-bold mb-2'>{client.name}</h1>
-							<div className='flex items-center gap-4 text-sm text-muted-foreground'>
+							<h1 className='text-4xl font-bold tracking-tight mb-2'>{client.name}</h1>
+							<div className='flex items-center gap-3 text-[13px] text-muted-foreground'>
 								<div className='flex items-center gap-1'>
 									<Building className='h-4 w-4' />
-									{client.type}
+									<span className='font-medium text-neutral-800 dark:text-neutral-200'>{client.type}</span>
 								</div>
+								<span className='text-neutral-300 dark:text-neutral-600 select-none'>&middot;</span>
 								<div className='flex items-center gap-1'>
 									<MapPin className='h-4 w-4' />
-									{[client.city, client.state_code].filter(Boolean).join(', ') || client.address}
+									<span className='font-medium text-neutral-800 dark:text-neutral-200'>
+										{[client.city, client.state_code].filter(Boolean).join(', ') || client.address}
+									</span>
 								</div>
+								<span className='text-neutral-300 dark:text-neutral-600 select-none'>&middot;</span>
 								<div className='flex items-center gap-1'>
 									<DollarSign className='h-4 w-4' />
-									{budgetDisplay}
+									<span className='font-medium text-neutral-800 dark:text-neutral-200'>{budgetDisplay}</span>
 								</div>
 							</div>
 						</div>
-						<Badge variant='outline' className='text-lg px-3 py-1'>
-							{matchCount} {matchCount === 1 ? 'Match' : 'Matches'}
+						<Badge variant='outline' className='text-sm px-3 py-1 whitespace-nowrap'>
+							{groupedSummary}
 						</Badge>
 					</div>
-
-					{/* Client Details Card */}
-					<Card>
-						<CardHeader>
-							<CardTitle className='flex items-center gap-2'>
-								<User className='h-5 w-5' />
-								Client Profile
-							</CardTitle>
-						</CardHeader>
-						<CardContent>
-							<div className='space-y-4'>
-								{/* Description */}
-								{client.description && (
-									<div>
-										<h4 className='font-medium mb-2'>About</h4>
-										<p className='text-sm text-muted-foreground'>{client.description}</p>
-									</div>
-								)}
-
-								{/* Project Needs */}
-								<div>
-									<h4 className='font-medium mb-2 flex items-center gap-2'>
-										<Target className='h-4 w-4' />
-										Project Needs
-									</h4>
-									<div className='flex flex-wrap gap-2'>
-										{formatProjectNeeds(client.project_needs).map((need, index) => (
-											<Badge
-												key={index}
-												variant='outline'
-												className='px-3 py-1 bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800 text-blue-700 dark:text-blue-300'
-											>
-												{need}
-											</Badge>
-										))}
-									</div>
-									{(!client.project_needs || client.project_needs.length === 0) && (
-										<p className='text-sm text-muted-foreground italic'>No project needs specified</p>
-									)}
-								</div>
-
-								{/* Match Breakdown */}
-								<div>
-									<h4 className='font-medium mb-2'>Match Breakdown</h4>
-									<div className='flex flex-wrap gap-2'>
-										{tags.map((tag, index) => (
-											<Badge key={index} variant='secondary'>
-												{tag}
-											</Badge>
-										))}
-									</div>
-								</div>
-							</div>
-						</CardContent>
-					</Card>
 				</div>
 
-				{/* Matches Section */}
+				{/* Client Profile — lightweight section */}
+				<div className='mb-6 rounded-lg border border-neutral-200 dark:border-neutral-800 border-l-[4px] border-l-blue-500 bg-blue-50/30 dark:bg-blue-950/20 px-5 py-4'>
+					<p className='text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400 mb-3'>
+						Client Profile
+					</p>
+					<div className='space-y-3'>
+						{/* Description */}
+						{client.description && (
+							<div>
+								<p className='text-sm text-neutral-600 dark:text-neutral-400 leading-relaxed'>{client.description}</p>
+							</div>
+						)}
+
+						{/* Project Needs with match counts (merged) */}
+						<div>
+							<p className='text-[11px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400 mb-2 flex items-center gap-2'>
+								<Target className='h-3.5 w-3.5' />
+								Project Needs
+							</p>
+							<div className='flex flex-wrap gap-2'>
+								{needsWithCounts.map((item, index) => (
+									<Badge
+										key={index}
+										variant='outline'
+										className={`px-3 py-1 text-xs ${
+											item.count > 0
+												? 'bg-blue-50 text-blue-800 border-blue-200 dark:bg-blue-950/50 dark:text-blue-300 dark:border-blue-800'
+												: 'bg-white text-neutral-500 border-neutral-300 dark:bg-neutral-800 dark:text-neutral-400 dark:border-neutral-600'
+										}`}
+									>
+										{item.count > 0 ? `${item.need} (${item.count})` : item.need}
+									</Badge>
+								))}
+							</div>
+							{(!client.project_needs || client.project_needs.length === 0) && (
+								<p className='text-sm text-muted-foreground italic'>No project needs specified</p>
+							)}
+						</div>
+					</div>
+				</div>
+
+				{/* Funding Opportunities — grouped by type */}
 				<div className='mb-6'>
 					<Tabs value={activeTab} onValueChange={setActiveTab}>
 						<div className='flex items-center justify-between mb-4'>
-							<h2 className='text-2xl font-bold'>Funding Opportunities</h2>
+							<h2 className='text-xl font-semibold tracking-tight text-neutral-900 dark:text-neutral-50'>
+								Funding Opportunities
+							</h2>
 							<TabsList>
 								<TabsTrigger value='matches'>
 									Matches ({matchCount})
@@ -231,29 +243,55 @@ export default function ClientMatchesPage() {
 
 						<TabsContent value='matches'>
 							{matchCount > 0 ? (
-								<div className='grid gap-6 md:grid-cols-2 lg:grid-cols-3'>
-									{matches.map((match) => (
-										<div key={match.id} className='relative group'>
-											<OpportunityCard
-												opportunity={match}
-												badgeOverride={
-													<span
-														className='text-xs px-2 py-1 rounded-full flex-shrink-0 ml-2 font-medium'
-														style={getMatchScoreBgColor(match.score)}
-													>
-														{formatMatchScore(match.score)}
-													</span>
-												}
-											/>
-											<div className='absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity'>
-												<HideMatchButton
-													clientId={clientId}
-													opportunityId={match.id}
-													opportunityTitle={match.title}
-													onHidden={handleMatchHidden}
-												/>
+								<div className='space-y-8'>
+									{groupedMatches.map((group, groupIndex) => (
+										<section key={group.key}>
+											{/* Group header */}
+											<div className={`flex items-center gap-3 mb-4 ${groupIndex > 0 ? 'pt-6 border-t border-neutral-200 dark:border-neutral-800' : ''}`}>
+												<span className='w-2 h-2 rounded-full flex-shrink-0' style={{ backgroundColor: getFundingGroupDotColor(group.key) }} />
+												<h3 className='text-xs font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400'>
+													{group.label}
+												</h3>
+												<span className='text-xs text-neutral-400 dark:text-neutral-500'>
+													{group.description}
+												</span>
+												<div className='flex-1 h-px bg-neutral-200 dark:bg-neutral-800' />
+												<Badge variant='secondary' className='text-xs'>
+													{group.matches.length}
+												</Badge>
 											</div>
-										</div>
+
+											{/* Cards grid */}
+											<div className='grid gap-6 sm:grid-cols-2 lg:grid-cols-3'>
+												{group.matches.map((match) => (
+													<div key={match.id} className='rounded-lg overflow-hidden border border-neutral-200 dark:border-neutral-700 flex flex-col'>
+														{/* Top accent bar */}
+														<div className='h-1.5 w-full bg-blue-500 dark:bg-blue-400' />
+														{/* Match context strip */}
+														<div className='flex items-center justify-between px-3 py-2 bg-neutral-100/80 dark:bg-neutral-800/60 border-b border-neutral-200 dark:border-neutral-700'>
+															<span
+																className='text-xs font-medium px-2 py-0.5 rounded-full'
+																style={getMatchScoreBadgeStyles(match.score)}
+															>
+																{formatMatchScore(match.score)}
+															</span>
+															<HideMatchButton
+																clientId={clientId}
+																opportunityId={match.id}
+																opportunityTitle={match.title}
+																onHidden={handleMatchHidden}
+															/>
+														</div>
+														{/* Card — border/radius nullified, internal accent bars hidden (outer wrapper provides them) */}
+														<div className='[&>a>div]:border-0 [&>a>div]:rounded-none [&>a]:rounded-none [&_.bg-blue-500]:hidden [&_.dark\:bg-blue-400]:hidden flex-grow'>
+															<OpportunityCard opportunity={match} />
+														</div>
+														{/* Bottom accent bar */}
+														<div className='h-1.5 w-full bg-blue-500 dark:bg-blue-400' />
+													</div>
+												))}
+											</div>
+										</section>
 									))}
 								</div>
 							) : (
@@ -261,7 +299,7 @@ export default function ClientMatchesPage() {
 									<AlertTriangle className='h-4 w-4' />
 									<AlertTitle>No Matches Found</AlertTitle>
 									<AlertDescription>
-										No funding opportunities currently match this client's criteria. Try adjusting the client's project needs or location requirements.
+										No funding opportunities currently match this client&apos;s criteria. Try adjusting the client&apos;s project needs or location requirements.
 									</AlertDescription>
 								</Alert>
 							)}

--- a/app/clients/page.jsx
+++ b/app/clients/page.jsx
@@ -634,13 +634,53 @@ function ClientCard({ clientResult, onViewProfile }) {
 	const locationParts = [client.city, client.state_code].filter(Boolean);
 	const location = locationParts.length > 0 ? locationParts.join(', ') : client.address;
 
+	// Find the most recent new match within 7 days
+	const newestNewMatch = useMemo(() => {
+		if (!matches || matches.length === 0) return null;
+		const now = new Date();
+		const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+		let newest = null;
+		for (const m of matches) {
+			if (m.is_new && m.first_matched_at) {
+				const matchDate = new Date(m.first_matched_at);
+				if (now - matchDate <= sevenDaysMs) {
+					if (!newest || matchDate > new Date(newest.first_matched_at)) {
+						newest = m;
+					}
+				}
+			}
+		}
+		return newest;
+	}, [matches]);
+
+	const newMatchLabel = useMemo(() => {
+		if (!newestNewMatch) return null;
+		const today = new Date();
+		const matchDate = new Date(newestNewMatch.first_matched_at);
+		today.setHours(0, 0, 0, 0);
+		matchDate.setHours(0, 0, 0, 0);
+		const daysAgo = Math.round((today - matchDate) / (1000 * 60 * 60 * 24));
+		if (daysAgo === 0) return 'NEW MATCH • Today';
+		if (daysAgo === 1) return 'NEW MATCH • Yesterday';
+		return `NEW MATCH • ${daysAgo} days ago`;
+	}, [newestNewMatch]);
+
 	return (
 		<Card className='overflow-hidden flex flex-col h-full'>
 			{/* Blue stripe at top */}
 			<div className='h-1.5 w-full bg-blue-600' />
 			<CardHeader className='pb-4'>
-				<CardTitle className='text-xl font-bold'>{client.name}</CardTitle>
-				<CardDescription className='text-sm text-muted-foreground'>{location}</CardDescription>
+				<div className='flex items-start justify-between gap-2'>
+					<div>
+						<CardTitle className='text-xl font-bold'>{client.name}</CardTitle>
+						<CardDescription className='text-sm text-muted-foreground'>{location}</CardDescription>
+					</div>
+					{newMatchLabel && (
+						<span className='text-[10px] font-semibold px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 whitespace-nowrap flex-shrink-0'>
+							{newMatchLabel}
+						</span>
+					)}
+				</div>
 			</CardHeader>
 			<CardContent className='px-6 pb-6 flex flex-col flex-1'>
 				<div className='flex-1 space-y-5'>
@@ -664,7 +704,14 @@ function ClientCard({ clientResult, onViewProfile }) {
 									<li
 										key={`${client.name}-${match.id}-${index}`}
 										className='text-sm border-l-2 border-blue-500 pl-3 py-1 hover:bg-blue-50 dark:hover:bg-blue-900/10 transition-colors duration-200 cursor-pointer rounded-r'>
-										<div className='font-medium truncate pr-12'>{match.title}</div>
+										<div className='font-medium truncate pr-12'>
+											{match.is_new && (
+												<span className='text-[10px] font-semibold px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300 mr-1.5 inline-block'>
+													NEW
+												</span>
+											)}
+											{match.title}
+										</div>
 										<div className='flex justify-between items-center'>
 											<span className='text-xs text-gray-500 dark:text-gray-400 truncate flex-1 pr-2'>
 												{match.agency_name || 'Unknown Agency'}

--- a/components/opportunities/OpportunityCard.jsx
+++ b/components/opportunities/OpportunityCard.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import {
 	Card,
 	CardHeader,
@@ -6,114 +6,93 @@ import {
 	CardTitle,
 } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { DollarSign, Calendar, Map, Star, Tag, Info } from 'lucide-react';
+import { DollarSign, Calendar, MapPin, Star, Sparkles, ArrowRight } from 'lucide-react';
 import { calculateDaysLeft, determineStatus } from '@/lib/supabase';
 import { useTrackedOpportunitiesStore } from '@/lib/stores';
-import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import {
-	getCategoryColor,
-	formatCategoryForDisplay,
 	getProjectTypeColor,
 	prioritizeProjectTypes,
 } from '@/lib/utils/uiHelpers';
 
-// Status indicators with colors for badges
-const statusIndicator = {
-	open: { color: '#2563EB', bgColor: '#EFF6FF', display: 'Open' },
-	upcoming: { color: '#4CAF50', bgColor: '#E8F5E9', display: 'Upcoming' },
-	closed: { color: '#EF4444', bgColor: '#FEF2F2', display: 'Closed' },
+// Status badge styles — border-only pills with tinted backgrounds
+const statusStyles = {
+	open: {
+		classes: 'border-blue-300 text-blue-700 bg-blue-50 dark:border-blue-700 dark:text-blue-400 dark:bg-blue-950/50',
+		display: 'Open',
+	},
+	upcoming: {
+		classes: 'border-emerald-300 text-emerald-700 bg-emerald-50 dark:border-emerald-700 dark:text-emerald-400 dark:bg-emerald-950/50',
+		display: 'Upcoming',
+	},
+	closed: {
+		classes: 'border-neutral-300 text-neutral-500 bg-neutral-50 dark:border-neutral-700 dark:text-neutral-400 dark:bg-neutral-800/50',
+		display: 'Closed',
+	},
 };
 
-// Helper to get status color regardless of case
-const getStatusColor = (status) => {
-	if (!status) return '#9E9E9E';
-	const statusKey = status.toLowerCase();
-	return statusIndicator[statusKey]?.color || '#9E9E9E';
+const getStatusStyle = (status) => {
+	if (!status) return statusStyles.open;
+	return statusStyles[status.toLowerCase()] || statusStyles.open;
 };
 
-// Helper to format status for display
 const formatStatusForDisplay = (status) => {
 	if (!status) return '';
-	const statusKey = status.toLowerCase();
-	return (
-		statusIndicator[statusKey]?.display ||
-		status.charAt(0).toUpperCase() + status.slice(1).toLowerCase()
-	);
+	const key = status.toLowerCase();
+	return statusStyles[key]?.display || status.charAt(0).toUpperCase() + status.slice(1).toLowerCase();
 };
 
-// Get relevance color based on the raw relevance score (0-10 scale)
-const getRelevanceColor = (score) => {
-	// Normalize score to 0-10 range
-	const normalizedScore = Math.min(10, Math.max(0, score));
-
-	if (normalizedScore >= 8) return '#4CAF50'; // High relevance - green
-	if (normalizedScore >= 6) return '#FF9800'; // Medium relevance - orange
-	return '#9E9E9E'; // Low relevance - gray
+// Relevance score colors and labels
+const getRelevanceConfig = (score) => {
+	const s = Math.min(10, Math.max(0, score));
+	if (s >= 8) return {
+		color: '#059669', barColor: '#10b981',
+		chipClasses: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/50 dark:text-emerald-400 dark:border-emerald-800',
+		barBg: 'bg-emerald-100 dark:bg-emerald-900/30',
+	};
+	if (s >= 6) return {
+		color: '#d97706', barColor: '#f59e0b',
+		chipClasses: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-800',
+		barBg: 'bg-amber-100 dark:bg-amber-900/30',
+	};
+	return {
+		color: '#6b7280', barColor: '#9ca3af',
+		chipClasses: 'bg-neutral-100 text-neutral-500 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-400 dark:border-neutral-700',
+		barBg: 'bg-neutral-100 dark:bg-neutral-800',
+	};
 };
 
-// Helper to format location eligibility for display
+// Top accent bar — consistent brand color
+const ACCENT_BAR_COLOR = 'bg-blue-500 dark:bg-blue-400';
+
+// Format location eligibility
 const formatLocationEligibility = (opportunity) => {
-	// Check if opportunity is national
-	if (opportunity.is_national) {
-		return 'National';
-	}
-
-	// Check for coverage_state_codes array from coverage_areas system
-	if (opportunity.coverage_state_codes && opportunity.coverage_state_codes.length > 0) {
+	if (opportunity.is_national) return 'National';
+	if (opportunity.coverage_state_codes?.length > 0) {
 		if (opportunity.coverage_state_codes.length > 3) {
-			return `${opportunity.coverage_state_codes.slice(0, 3).join(', ')} +${
-				opportunity.coverage_state_codes.length - 3
-			} more`;
+			return `${opportunity.coverage_state_codes.slice(0, 3).join(', ')} +${opportunity.coverage_state_codes.length - 3} more`;
 		}
 		return opportunity.coverage_state_codes.join(', ');
 	}
-
-	// Fallback to eligible_locations array
-	if (
-		opportunity.eligible_locations &&
-		opportunity.eligible_locations.length > 0
-	) {
-		// If it contains 'National', show that
-		if (opportunity.eligible_locations.includes('National')) {
-			return 'National';
-		}
-
-		// Otherwise, show the list of locations
+	if (opportunity.eligible_locations?.length > 0) {
+		if (opportunity.eligible_locations.includes('National')) return 'National';
 		if (opportunity.eligible_locations.length > 3) {
-			return `${opportunity.eligible_locations.slice(0, 3).join(', ')} +${
-				opportunity.eligible_locations.length - 3
-			} more`;
+			return `${opportunity.eligible_locations.slice(0, 3).join(', ')} +${opportunity.eligible_locations.length - 3} more`;
 		}
 		return opportunity.eligible_locations.join(', ');
 	}
-
-	// Default if no location data
 	return 'Location not specified';
 };
 
-// Badge colors are now handled via Tailwind classes for dark mode support
-
 const OpportunityCard = ({ opportunity, badgeOverride }) => {
-	// Use Next.js router and search params
-	const router = useRouter();
-	const pathname = usePathname();
-	const searchParams = useSearchParams();
-
-	// Use Zustand store for tracking opportunities
-	// Subscribe to trackedOpportunityIds directly so the component re-renders
-	// when the array changes (selecting s.isTracked returns a stable function
-	// reference that never triggers re-renders).
 	const trackedIds = useTrackedOpportunitiesStore((s) => s.trackedOpportunityIds);
 	const toggleTracked = useTrackedOpportunitiesStore((s) => s.toggleTracked);
-
-	// Check if this opportunity is being tracked
 	const opportunityIsTracked = trackedIds.includes(opportunity.id);
 
-	// Format the data from our database to match the UI expectations
+	// Derived data
 	const title = opportunity.title;
+	const fundingType = opportunity.funding_type || null;
 
-	// Format amount display
 	const amount =
 		opportunity.minimum_award && opportunity.maximum_award
 			? `$${opportunity.minimum_award.toLocaleString()} - $${opportunity.maximum_award.toLocaleString()}`
@@ -125,263 +104,226 @@ const OpportunityCard = ({ opportunity, badgeOverride }) => {
 			? `$${opportunity.total_funding_available.toLocaleString()} total`
 			: 'Amount not specified';
 
-	// Format close date
 	const closeDate = opportunity.close_date
 		? new Date(opportunity.close_date).toLocaleDateString('en-US', {
 				month: 'short',
 				day: 'numeric',
 				year: 'numeric',
 		  })
-		: 'No deadline specified';
+		: 'No deadline';
 
-	// Format location eligibility
 	const locationEligibility = formatLocationEligibility(opportunity);
 
-	// Determine status
 	const status =
 		opportunity.status ||
 		determineStatus(opportunity.open_date, opportunity.close_date);
-
-	// Format status for display (ensuring correct capitalization)
+	const statusStyle = getStatusStyle(status);
 	const displayStatus = formatStatusForDisplay(status);
 
-	// Use program overview if available, fall back to description
 	const summary =
 		opportunity.program_overview ||
 		opportunity.description ||
 		'No description available';
 
-	// Get tags
-	const tags = opportunity.tags || [];
-
-	// Determine if opportunity is new (added in the last 6 days)
+	// Freshness badges
 	const isNew =
 		opportunity.created_at &&
-		(new Date() - new Date(opportunity.created_at)) / (1000 * 60 * 60 * 24) <=
-			6;
+		(new Date() - new Date(opportunity.created_at)) / (1000 * 60 * 60 * 24) <= 6;
 
-	// Determine if opportunity was recently updated (within last 7 days, but not new)
 	const isNewlyUpdated =
 		!isNew &&
 		opportunity.updated_at &&
 		opportunity.created_at !== opportunity.updated_at &&
-		(new Date() - new Date(opportunity.updated_at)) / (1000 * 60 * 60 * 24) <=
-			7;
+		(new Date() - new Date(opportunity.updated_at)) / (1000 * 60 * 60 * 24) <= 7;
 
-	// Calculate days since creation if it's new
-	const addedDaysAgo =
-		isNew && opportunity.created_at
-			? (() => {
-					const today = new Date();
-					const createdDate = new Date(opportunity.created_at);
+	const getDaysAgo = (dateStr) => {
+		if (!dateStr) return null;
+		const today = new Date();
+		const date = new Date(dateStr);
+		today.setHours(0, 0, 0, 0);
+		date.setHours(0, 0, 0, 0);
+		return Math.round((today - date) / (1000 * 60 * 60 * 24));
+	};
 
-					// Reset hours to compare calendar days only
-					today.setHours(0, 0, 0, 0);
-					createdDate.setHours(0, 0, 0, 0);
+	const addedDaysAgo = isNew ? getDaysAgo(opportunity.created_at) : null;
+	const updatedDaysAgo = isNewlyUpdated ? getDaysAgo(opportunity.updated_at) : null;
 
-					// Calculate difference in days
-					return Math.round((today - createdDate) / (1000 * 60 * 60 * 24));
-			  })()
-			: null;
+	const formatDaysAgo = (days) =>
+		days === 0 ? 'Today' : days === 1 ? 'Yesterday' : `${days}d ago`;
 
-	// Calculate days since update if it was newly updated
-	const updatedDaysAgo =
-		isNewlyUpdated && opportunity.updated_at
-			? (() => {
-					const today = new Date();
-					const updatedDate = new Date(opportunity.updated_at);
-
-					// Reset hours to compare calendar days only
-					today.setHours(0, 0, 0, 0);
-					updatedDate.setHours(0, 0, 0, 0);
-
-					// Calculate difference in days
-					return Math.round((today - updatedDate) / (1000 * 60 * 60 * 24));
-			  })()
-			: null;
-
-	// Get relevance score if available - handle both old and new scoring formats
-	const relevanceScore = opportunity.relevance_score ||
+	// Relevance score
+	const relevanceScore =
+		opportunity.relevance_score ||
 		opportunity.scoring?.finalScore ||
 		opportunity.scoring?.overallScore ||
 		null;
 
-	// Extract categories - for now, we'll use tags as categories if categories aren't available
-	const categories =
-		opportunity.categories || (tags.length > 0 ? [tags[0]] : ['Other']);
-
-	// Get prioritized project types (top 3 based on taxonomy)
+	// Project types — top 3 by taxonomy tier
 	const projectTypes = prioritizeProjectTypes(opportunity.eligible_project_types || [], 3);
 
-	// Function to handle tracking
 	const handleTrackToggle = useCallback(
 		(e) => {
-			e.preventDefault(); // Prevent link navigation
-			e.stopPropagation(); // Prevent event bubbling up to parent elements
-			e.nativeEvent.stopImmediatePropagation(); // Stop all other event handlers
-
-			// Toggle the tracked status
+			e.preventDefault();
+			e.stopPropagation();
+			e.nativeEvent.stopImmediatePropagation();
 			toggleTracked(opportunity.id);
 		},
 		[toggleTracked, opportunity.id]
 	);
 
 	return (
-		<Card className='overflow-hidden hover:shadow-md transition-shadow duration-200 flex flex-col h-full relative'>
-			{/* Thin blue bar at the top */}
-			<div className='h-1.5 w-full bg-blue-600 rounded-t-lg' />
+		<Link href={`/funding/opportunities/${opportunity.id}`} className='block h-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 rounded-lg'>
+		<Card className='overflow-hidden hover:shadow-lg hover:-translate-y-0.5 transition-all duration-150 flex flex-col h-full relative border border-neutral-200 dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-sm group cursor-pointer'>
+			{/* Brand accent bar */}
+			<div className={`h-1.5 w-full ${ACCENT_BAR_COLOR}`} />
 
-			<CardHeader className='pb-3'>
-				<div className='flex justify-between items-start'>
-					<CardTitle className='text-lg line-clamp-2'>{title}</CardTitle>
+			<CardHeader className='px-4 pt-3 pb-2'>
+				{/* Title + Status row */}
+				<div className='flex justify-between items-start gap-2'>
+					<CardTitle className='text-base font-semibold leading-snug tracking-tight line-clamp-2 text-neutral-900 dark:text-neutral-50' title={title}>
+						{title}
+					</CardTitle>
 
-					{/* Status badge OR custom badge override */}
-					{badgeOverride ? (
-						badgeOverride
-					) : (
-						<span
-							className='text-xs px-2 py-1 rounded-full flex-shrink-0 ml-2 font-medium'
-							style={{
-								backgroundColor: getStatusColor(status),
-								color: 'white',
-							}}>
+					{badgeOverride || (
+						<span className={`text-[10px] px-2 py-0.5 rounded-full border font-medium flex-shrink-0 whitespace-nowrap ${statusStyle.classes}`}>
 							{displayStatus}
 						</span>
 					)}
 				</div>
 
-				{/* NEW badge if applicable - updated to match category pill styling */}
-				{isNew && (
-					<div className='mt-2'>
-						<span className='text-xs font-medium px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'>
-							NEW •{' '}
-							{addedDaysAgo === 0
-								? 'Today'
-								: addedDaysAgo === 1
-								? 'Yesterday'
-								: `${addedDaysAgo} days ago`}
+				{/* Meta row: funding type + freshness badges */}
+				<div className='flex items-center gap-1.5 flex-wrap mt-1.5'>
+					{fundingType && (
+						<span className='text-[11px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded border border-neutral-300 text-neutral-700 bg-neutral-50 dark:border-neutral-600 dark:text-neutral-300 dark:bg-neutral-800/50'>
+							{fundingType}
 						</span>
-					</div>
-				)}
-
-				{/* NEWLY UPDATED badge if applicable */}
-				{isNewlyUpdated && (
-					<div className='mt-2'>
-						<span className='text-xs font-medium px-2 py-1 rounded bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300'>
-							UPDATED •{' '}
-							{updatedDaysAgo === 0
-								? 'Today'
-								: updatedDaysAgo === 1
-								? 'Yesterday'
-								: `${updatedDaysAgo} days ago`}
+					)}
+					{isNew && (
+						<span className='flex items-center gap-1 text-[10px] font-medium text-blue-600 dark:text-blue-400'>
+							<span className='w-1.5 h-1.5 rounded-full bg-blue-500' />
+							New {formatDaysAgo(addedDaysAgo)}
 						</span>
-					</div>
-				)}
+					)}
+					{isNewlyUpdated && (
+						<span className='flex items-center gap-1 text-[10px] font-medium text-sky-600 dark:text-sky-400'>
+							<span className='w-1.5 h-1.5 rounded-full bg-sky-500' />
+							Updated {formatDaysAgo(updatedDaysAgo)}
+						</span>
+					)}
+				</div>
 			</CardHeader>
 
-			<CardContent className='flex-grow flex flex-col pt-0'>
-				<div className='space-y-4 flex-grow'>
-					{/* Summary */}
-					<p className='text-sm text-neutral-600 dark:text-neutral-400'>{summary}</p>
+			<CardContent className='flex-grow flex flex-col pt-0 px-4 pb-4'>
+				<div className='space-y-3 flex-grow'>
+					{/* Summary — truncated to 3 lines */}
+					<p className='text-sm text-neutral-600 dark:text-neutral-400 line-clamp-3 leading-relaxed'>
+						{summary}
+					</p>
 
-					{/* Project type pills */}
-					<div className='flex flex-wrap gap-1'>
+					{/* Project type pills — left-edge color stripe */}
+					<div className='flex flex-wrap gap-1.5' role='list'>
 						{projectTypes.map((projectType, index) => {
-							const projectTypeColor = getProjectTypeColor(projectType);
+							const typeColor = getProjectTypeColor(projectType);
 							return (
 								<span
 									key={index}
-									className='project-type-tag text-xs px-2 py-1 rounded'
-									style={{
-										backgroundColor: projectTypeColor.bgColor,
-										color: projectTypeColor.color,
-									}}>
+									role='listitem'
+									className='text-[11px] font-medium px-2 py-0.5 rounded-md border border-l-2 bg-neutral-50 text-neutral-700 border-neutral-200 dark:bg-neutral-800/50 dark:text-neutral-300 dark:border-neutral-700'
+									style={{ borderLeftColor: typeColor.color }}>
 									{projectType}
 								</span>
 							);
 						})}
 					</div>
 
-					{/* Key details */}
-					<div className='space-y-2 text-sm'>
+					{/* Key details — compact */}
+					<div className='space-y-1.5'>
 						<div className='flex items-center gap-2'>
-							<DollarSign size={16} className='text-neutral-500 dark:text-neutral-400' />
-							<span>{amount}</span>
+							<DollarSign size={14} className='text-neutral-400 dark:text-neutral-500 flex-shrink-0' />
+							<span className='text-sm font-medium text-neutral-700 dark:text-neutral-300'>{amount}</span>
 						</div>
-
 						<div className='flex items-center gap-2'>
-							<Calendar size={16} className='text-neutral-500 dark:text-neutral-400' />
-							<span>{closeDate}</span>
+							<Calendar size={14} className='text-neutral-400 dark:text-neutral-500 flex-shrink-0' />
+							<span className='text-xs text-neutral-500 dark:text-neutral-400'>{closeDate}</span>
 						</div>
-
 						<div className='flex items-center gap-2'>
-							<Map size={16} className='text-neutral-500 dark:text-neutral-400' />
-							<span className='line-clamp-1'>{locationEligibility}</span>
+							<MapPin size={14} className='text-neutral-400 dark:text-neutral-500 flex-shrink-0' />
+							<span className='text-xs text-neutral-500 dark:text-neutral-400 line-clamp-1'>{locationEligibility}</span>
 						</div>
 					</div>
 				</div>
 
-				{/* Footer section with relevance score and buttons - fixed at bottom */}
-				<div className='pt-4 mt-auto'>
-					{/* Relevance score if available */}
-					{relevanceScore !== null && relevanceScore !== undefined && (
-						<div className='flex items-center gap-2 mb-4'>
-							<div className='flex-grow bg-neutral-200 dark:bg-neutral-700 h-2 rounded-full overflow-hidden'>
-								<div
-									className='h-full rounded-full'
-									style={{
-										width: `${Math.max(
-											0,
-											Math.min(100, (Math.min(10, relevanceScore) / 10) * 100)
-										)}%`, // Ensure max is 100%
-										backgroundColor: getRelevanceColor(relevanceScore),
-									}}></div>
+				{/* Footer: Relevance score + actions */}
+				<div className='pt-3 mt-auto border-t border-neutral-100 dark:border-neutral-800'>
+					{/* Relevance score — labeled module */}
+					{relevanceScore !== null && relevanceScore !== undefined && (() => {
+						const config = getRelevanceConfig(relevanceScore);
+						const normalizedScore = Math.min(10, relevanceScore);
+						const percentage = Math.max(0, Math.min(100, (normalizedScore / 10) * 100));
+						return (
+							<div
+								className='flex items-center gap-2 mb-3'
+								aria-label={`Relevance score: ${normalizedScore.toFixed(1)} out of 10`}
+							>
+								<div className='flex items-center gap-1'>
+									<Sparkles size={12} style={{ color: config.color }} />
+									<span className='text-[10px] font-semibold uppercase tracking-wider text-neutral-500 dark:text-neutral-400'>
+										Relevance
+									</span>
+								</div>
+								<span className={`text-xs font-bold px-2 py-0.5 rounded border ${config.chipClasses}`}>
+									{normalizedScore.toFixed(1)}
+								</span>
+								<div className={`flex-grow h-1.5 rounded-full overflow-hidden ${config.barBg}`}>
+									<div
+										className='h-full rounded-full transition-all duration-300'
+										style={{
+											width: `${percentage}%`,
+											backgroundColor: config.barColor,
+										}}
+									/>
+								</div>
 							</div>
-							<span
-								className='text-xs font-medium whitespace-nowrap'
-								style={{ color: getRelevanceColor(relevanceScore) }}>
-								{Math.min(10, relevanceScore).toFixed(1)}/10
-							</span>
-						</div>
-					)}
+						);
+					})()}
 
-					{/* Button row with View Details and Track buttons */}
-					<div className='flex gap-2'>
-						<Button className='flex-1' asChild>
-							<Link href={`/funding/opportunities/${opportunity.id}`}>
-								View Details
-							</Link>
-						</Button>
-
+					{/* Footer actions — quiet text link + compact Track */}
+					<div className='flex items-center justify-between'>
+						<span className='text-sm text-neutral-500 group-hover:text-primary dark:text-neutral-400 dark:group-hover:text-primary transition-colors flex items-center gap-1'>
+							View Details
+							<ArrowRight className='h-3.5 w-3.5 opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200' />
+						</span>
 						<Button
-							variant={opportunityIsTracked ? 'outline' : 'outline'}
-							className={
+							variant='ghost'
+							size='sm'
+							className={`h-7 text-xs px-2 ${
 								opportunityIsTracked
-									? 'border-slate-200 dark:border-slate-700 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/30 flex-1'
-									: 'border-slate-200 dark:border-slate-700 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 flex-1'
-							}
+									? 'text-amber-700 hover:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-950/30'
+									: 'text-neutral-500 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800'
+							}`}
 							onClick={handleTrackToggle}
 							onMouseDown={(e) => e.stopPropagation()}
 							onTouchStart={(e) => e.stopPropagation()}
 							data-track-button='true'
-							title={
-								opportunityIsTracked
-									? 'Remove from tracked opportunities'
-									: 'Add to tracked opportunities'
-							}>
+							aria-label={opportunityIsTracked ? 'Remove from tracked opportunities' : 'Add to tracked opportunities'}
+							aria-pressed={opportunityIsTracked}
+						>
 							<Star
-								className={`h-4 w-4 mr-2 ${
+								className={`h-3.5 w-3.5 mr-1 ${
 									opportunityIsTracked
 										? 'fill-amber-500 text-amber-500'
-										: 'fill-none text-slate-500'
+										: 'fill-none text-neutral-400'
 								}`}
 							/>
-							{opportunityIsTracked ? 'Untrack' : 'Track'}
+							{opportunityIsTracked ? 'Tracked' : 'Track'}
 						</Button>
 					</div>
 				</div>
 			</CardContent>
+			{/* Bottom accent bar — bookend */}
+			<div className={`h-1.5 w-full mt-auto ${ACCENT_BAR_COLOR}`} />
 		</Card>
+		</Link>
 	);
 };
 

--- a/components/opportunities/OpportunityCard.jsx
+++ b/components/opportunities/OpportunityCard.jsx
@@ -200,6 +200,25 @@ const OpportunityCard = ({ opportunity, badgeOverride }) => {
 			  })()
 			: null;
 
+	// Determine if this is a new match (is_new flag set AND matched within last 7 days)
+	const isNewMatch =
+		opportunity.is_new === true &&
+		opportunity.first_matched_at &&
+		(new Date() - new Date(opportunity.first_matched_at)) / (1000 * 60 * 60 * 24) <= 7;
+
+
+
+	const matchedDaysAgo =
+		isNewMatch && opportunity.first_matched_at
+			? (() => {
+					const today = new Date();
+					const matchedDate = new Date(opportunity.first_matched_at);
+					today.setHours(0, 0, 0, 0);
+					matchedDate.setHours(0, 0, 0, 0);
+					return Math.round((today - matchedDate) / (1000 * 60 * 60 * 24));
+			  })()
+			: null;
+
 	// Get relevance score if available - handle both old and new scoring formats
 	const relevanceScore = opportunity.relevance_score ||
 		opportunity.scoring?.finalScore ||
@@ -250,31 +269,39 @@ const OpportunityCard = ({ opportunity, badgeOverride }) => {
 					)}
 				</div>
 
-				{/* NEW badge if applicable - updated to match category pill styling */}
-				{isNew && (
-					<div className='mt-2'>
-						<span className='text-xs font-medium px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'>
-							NEW •{' '}
-							{addedDaysAgo === 0
-								? 'Today'
-								: addedDaysAgo === 1
-								? 'Yesterday'
-								: `${addedDaysAgo} days ago`}
-						</span>
-					</div>
-				)}
-
-				{/* NEWLY UPDATED badge if applicable */}
-				{isNewlyUpdated && (
-					<div className='mt-2'>
-						<span className='text-xs font-medium px-2 py-1 rounded bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300'>
-							UPDATED •{' '}
-							{updatedDaysAgo === 0
-								? 'Today'
-								: updatedDaysAgo === 1
-								? 'Yesterday'
-								: `${updatedDaysAgo} days ago`}
-						</span>
+				{/* Badge row: NEW, UPDATED, and NEW MATCH badges side by side */}
+				{(isNew || isNewlyUpdated || isNewMatch) && (
+					<div className='mt-2 flex flex-wrap gap-1.5'>
+						{isNew && (
+							<span className='text-xs font-medium px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'>
+								NEW •{' '}
+								{addedDaysAgo === 0
+									? 'Today'
+									: addedDaysAgo === 1
+									? 'Yesterday'
+									: `${addedDaysAgo} days ago`}
+							</span>
+						)}
+						{isNewlyUpdated && (
+							<span className='text-xs font-medium px-2 py-1 rounded bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-300'>
+								UPDATED •{' '}
+								{updatedDaysAgo === 0
+									? 'Today'
+									: updatedDaysAgo === 1
+									? 'Yesterday'
+									: `${updatedDaysAgo} days ago`}
+							</span>
+						)}
+						{isNewMatch && (
+							<span className='text-xs font-medium px-2 py-1 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'>
+								NEW MATCH •{' '}
+								{matchedDaysAgo === 0
+									? 'Today'
+									: matchedDaysAgo === 1
+									? 'Yesterday'
+									: `${matchedDaysAgo} days ago`}
+							</span>
+						)}
 					</div>
 				)}
 			</CardHeader>

--- a/lib/constants/taxonomies.js
+++ b/lib/constants/taxonomies.js
@@ -306,31 +306,31 @@ export const TAXONOMIES = {
 			// Direct Funding - MOST VALUABLE
 			'Grant',
 			'Direct Payment',
-			'Voucher',
-			'Rebate',
 		],
 
 		strong: [
-			// Tax Benefits - STRONG VALUE, NO REPAYMENT
+			// Upfront value or near-grant mechanisms - STRONG VALUE, NO REPAYMENT
 			'Tax Credit',
 			'Tax Incentive',
 			'Tax Deduction',
 			'Tax Exemption',
+			'Voucher',
+			'Cooperative Agreement',
 		],
 
 		mild: [
-			// Loans & Credit - NEEDS REPAYMENT
+			// Loans, credit & delayed-value mechanisms - NEEDS REPAYMENT OR DELAYED
 			'Loan',
 			'Forgivable Loan',
 			'Guarantee',
 			'Bond',
+			'Rebate',
 		],
 
 		weak: [
-			// Support Services & Agreements - NON-MONETARY
+			// Support Services - NON-MONETARY
 			'Technical Assistance',
 			'In-Kind Support',
-			'Cooperative Agreement',
 			'Contract',
 		],
 	},
@@ -895,5 +895,43 @@ export function getSelectableClientTypes() {
 
 	return Array.from(selectableTypes).sort();
 }
+
+/**
+ * Funding type display groups for UI — ordered by desirability.
+ * Used by client matches, opportunity explorer, and any view that groups by funding type.
+ * The "other" group is a catch-all for types not explicitly listed (e.g., Technical Assistance, Contract).
+ */
+export const FUNDING_TYPE_GROUPS = [
+	{
+		key: 'grants',
+		label: 'Grants',
+		description: 'Direct Grant Funding',
+		types: ['Grant', 'Cooperative Agreement'],
+	},
+	{
+		key: 'tax',
+		label: 'Tax Benefits',
+		description: 'Tax Incentives',
+		types: ['Tax Credit', 'Tax Incentive', 'Tax Deduction', 'Tax Exemption'],
+	},
+	{
+		key: 'loans',
+		label: 'Loans',
+		description: 'Loans & Credit',
+		types: ['Loan', 'Forgivable Loan', 'Guarantee', 'Bond'],
+	},
+	{
+		key: 'incentives',
+		label: 'Rebates & Incentives',
+		description: 'Utility Incentives',
+		types: ['Rebate', 'Direct Payment', 'Voucher'],
+	},
+	{
+		key: 'other',
+		label: 'Other',
+		description: 'Support & Services',
+		types: [], // catch-all for anything not in the above groups
+	},
+];
 
 export default TAXONOMIES;

--- a/lib/matching/computeMatches.js
+++ b/lib/matching/computeMatches.js
@@ -1,0 +1,295 @@
+/**
+ * Background match computation engine
+ *
+ * Computes client-opportunity matches and persists results to client_matches.
+ * Supports full recomputation (cron) and scoped computation (event triggers).
+ *
+ * Uses evaluateMatch.js as the single source of truth for matching logic.
+ */
+
+import { evaluateMatch } from './evaluateMatch.js';
+import { TAXONOMIES, getExpandedClientTypes } from '../constants/taxonomies.js';
+
+const MATCH_DEPS = {
+  hotActivities: TAXONOMIES.ELIGIBLE_ACTIVITIES.hot,
+  getExpandedClientTypes
+};
+
+/**
+ * Compute matches for ALL clients against ALL open opportunities.
+ * Used by the daily cron job.
+ */
+export async function computeAllMatches(supabase) {
+  return runMatchComputation(supabase, {
+    trigger: 'cron',
+    scope: {}
+  });
+}
+
+/**
+ * Compute matches for a single client against all open opportunities.
+ * Used after client create/update.
+ */
+export async function computeMatchesForClient(supabase, clientId, { trigger = 'client_updated' } = {}) {
+  return runMatchComputation(supabase, {
+    trigger,
+    scope: { clientIds: [clientId] }
+  });
+}
+
+/**
+ * Compute matches for specific opportunities against all clients.
+ * Used after pipeline Phase 6 stores new opportunities.
+ */
+export async function computeMatchesForOpportunities(supabase, opportunityIds) {
+  return runMatchComputation(supabase, {
+    trigger: 'opportunity_stored',
+    scope: { opportunityIds }
+  });
+}
+
+/**
+ * Core computation engine. Fetches data, runs evaluateMatch for each pair,
+ * UPSERTs results, and marks stale matches.
+ *
+ * @param {Object} supabase - Supabase client with service_role key
+ * @param {Object} options
+ * @param {string} options.trigger - What triggered this computation
+ * @param {Object} options.scope - { clientIds?: string[], opportunityIds?: string[] }
+ * @returns {Object} stats - { new_matches, updated_matches, stale_matches, duration_ms, ... }
+ */
+async function runMatchComputation(supabase, { trigger, scope }) {
+  const startTime = Date.now();
+
+  // Log job start
+  const { data: jobLog } = await supabase
+    .from('match_job_logs')
+    .insert({
+      trigger,
+      scope: scope || {},
+      status: 'running'
+    })
+    .select('id')
+    .single();
+
+  const jobId = jobLog?.id;
+
+  try {
+    // 1. Fetch clients (limit raised from Supabase default of 1,000)
+    let clientQuery = supabase.from('clients').select('id, name, type, coverage_area_ids, project_needs').limit(10000);
+    if (scope.clientIds?.length) {
+      clientQuery = clientQuery.in('id', scope.clientIds);
+    }
+    const { data: clients, error: clientError } = await clientQuery;
+    if (clientError) throw new Error(`Failed to fetch clients: ${clientError.message}`);
+    if (!clients?.length) {
+      return finishJob(supabase, jobId, startTime, { clients_processed: 0, message: 'No clients found' });
+    }
+
+    // 2. Fetch open opportunities (non-closed, promoted or null promotion_status)
+    let oppQuery = supabase
+      .from('funding_opportunities')
+      .select('id, eligible_applicants, eligible_project_types, eligible_activities, is_national')
+      .neq('status', 'closed')
+      .or('promotion_status.is.null,promotion_status.eq.promoted')
+      .limit(10000);
+    if (scope.opportunityIds?.length) {
+      oppQuery = oppQuery.in('id', scope.opportunityIds);
+    }
+    const { data: opportunities, error: oppError } = await oppQuery;
+    if (oppError) throw new Error(`Failed to fetch opportunities: ${oppError.message}`);
+    if (!opportunities?.length) {
+      return finishJob(supabase, jobId, startTime, { clients_processed: clients.length, opportunities_evaluated: 0, message: 'No opportunities found' });
+    }
+
+    // 3. Fetch coverage areas for opportunities
+    // For full runs, fetch all coverage links (avoids URL length limit with large ID lists).
+    // For scoped runs, filter by the specific opportunity IDs.
+    let coverageQuery = supabase
+      .from('opportunity_coverage_areas')
+      .select('opportunity_id, coverage_area_id')
+      .limit(50000);
+    if (scope.opportunityIds?.length) {
+      coverageQuery = coverageQuery.in('opportunity_id', scope.opportunityIds);
+    }
+    const { data: coverageLinks, error: coverageError } = await coverageQuery;
+    if (coverageError) throw new Error(`Failed to fetch coverage areas: ${coverageError.message}`);
+
+    // Build coverage area map
+    const coverageMap = {};
+    for (const link of coverageLinks || []) {
+      if (!coverageMap[link.opportunity_id]) coverageMap[link.opportunity_id] = [];
+      coverageMap[link.opportunity_id].push(link.coverage_area_id);
+    }
+    for (const opp of opportunities) {
+      opp.coverage_area_ids = coverageMap[opp.id] || [];
+    }
+
+    // 4. Compute all matches
+    const matchRows = [];
+    for (const client of clients) {
+      for (const opportunity of opportunities) {
+        const result = evaluateMatch(client, opportunity, MATCH_DEPS);
+        if (result.isMatch) {
+          matchRows.push({
+            client_id: client.id,
+            opportunity_id: opportunity.id,
+            score: result.score,
+            match_details: result.details
+          });
+        }
+      }
+    }
+
+    // 5. Fetch existing matches for the scope (needed for delta detection)
+    let existingQuery = supabase
+      .from('client_matches')
+      .select('client_id, opportunity_id')
+      .limit(100000);
+    if (scope.clientIds?.length) {
+      existingQuery = existingQuery.in('client_id', scope.clientIds);
+    }
+    if (scope.opportunityIds?.length) {
+      existingQuery = existingQuery.in('opportunity_id', scope.opportunityIds);
+    }
+    const { data: existingMatches } = await existingQuery;
+    const existingSet = new Set(
+      (existingMatches || []).map(m => `${m.client_id}:${m.opportunity_id}`)
+    );
+
+    // 6. UPSERT matches in batches
+    // Excludes is_new and first_matched_at from the payload so that:
+    // - New rows get DB defaults: is_new=true, first_matched_at=NOW()
+    // - Existing rows preserve their is_new and first_matched_at values
+    // Using .upsert() instead of separate INSERT+UPDATE avoids race conditions
+    // between concurrent triggers (cron, pipeline, client CRUD).
+    const newMatchKeys = new Set();
+    let newCount = 0;
+    let updatedCount = 0;
+    const BATCH_SIZE = 500;
+    const now = new Date().toISOString();
+
+    for (let i = 0; i < matchRows.length; i += BATCH_SIZE) {
+      const batch = matchRows.slice(i, i + BATCH_SIZE);
+      const { error: upsertError } = await supabase
+        .from('client_matches')
+        .upsert(
+          batch.map(row => ({
+            client_id: row.client_id,
+            opportunity_id: row.opportunity_id,
+            score: row.score,
+            match_details: row.match_details,
+            last_matched_at: now,
+            is_stale: false,
+            stale_at: null
+          })),
+          { onConflict: 'client_id,opportunity_id' }
+        );
+      if (upsertError) throw new Error(`UPSERT failed: ${upsertError.message}`);
+
+      for (const row of batch) {
+        const key = `${row.client_id}:${row.opportunity_id}`;
+        newMatchKeys.add(key);
+        if (existingSet.has(key)) {
+          updatedCount++;
+        } else {
+          newCount++;
+        }
+      }
+    }
+
+    // 7. Mark stale matches (existed before but not in new computation)
+    // Only mark stale within the scope being processed
+    const staleKeys = [];
+    for (const existing of existingMatches || []) {
+      const key = `${existing.client_id}:${existing.opportunity_id}`;
+      if (!newMatchKeys.has(key)) {
+        staleKeys.push(existing);
+      }
+    }
+
+    let staleCount = staleKeys.length;
+    if (staleKeys.length > 0) {
+      // Batch stale marking by client_id groups
+      const staleByClient = {};
+      for (const stale of staleKeys) {
+        if (!staleByClient[stale.client_id]) staleByClient[stale.client_id] = [];
+        staleByClient[stale.client_id].push(stale.opportunity_id);
+      }
+
+      for (const [clientId, oppIds] of Object.entries(staleByClient)) {
+        const { error: staleError } = await supabase
+          .from('client_matches')
+          .update({
+            is_stale: true,
+            stale_at: new Date().toISOString()
+          })
+          .eq('client_id', clientId)
+          .in('opportunity_id', oppIds)
+          .eq('is_stale', false); // Only update if not already stale
+
+        if (staleError) {
+          console.error(`[ComputeMatches] Stale marking failed for client ${clientId}:`, staleError.message);
+        }
+      }
+    }
+
+    // 8. Return stats
+    const stats = {
+      clients_processed: clients.length,
+      opportunities_evaluated: opportunities.length,
+      pairs_evaluated: clients.length * opportunities.length,
+      new_matches: newCount,
+      updated_matches: updatedCount,
+      stale_matches: staleCount,
+      total_active_matches: matchRows.length,
+      duration_ms: Date.now() - startTime
+    };
+
+    return finishJob(supabase, jobId, startTime, stats);
+
+  } catch (error) {
+    // Log failure
+    if (jobId) {
+      await supabase
+        .from('match_job_logs')
+        .update({
+          status: 'failed',
+          completed_at: new Date().toISOString(),
+          error: error.message,
+          stats: { duration_ms: Date.now() - startTime }
+        })
+        .eq('id', jobId);
+    }
+    console.error(`[ComputeMatches] Job failed (${trigger}):`, error.message);
+    throw error;
+  }
+}
+
+/**
+ * Finalize a job log with stats.
+ */
+async function finishJob(supabase, jobId, startTime, stats) {
+  const duration = Date.now() - startTime;
+  stats.duration_ms = duration;
+
+  if (jobId) {
+    await supabase
+      .from('match_job_logs')
+      .update({
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+        stats
+      })
+      .eq('id', jobId);
+  }
+
+  console.log(`[ComputeMatches] Job completed in ${duration}ms:`, {
+    new: stats.new_matches,
+    updated: stats.updated_matches,
+    stale: stats.stale_matches,
+    total: stats.total_active_matches
+  });
+
+  return stats;
+}

--- a/lib/matching/computeMatches.js
+++ b/lib/matching/computeMatches.js
@@ -157,6 +157,15 @@ async function runMatchComputation(supabase, { trigger, scope }) {
       (existingMatches || []).map(m => `${m.client_id}:${m.opportunity_id}`)
     );
 
+    // Identify clients with zero prior matches (first-ever computation).
+    // Their matches are "initial", not "new" — avoids badge noise on new clients.
+    const clientsWithExistingMatches = new Set(
+      (existingMatches || []).map(m => m.client_id)
+    );
+    const firstTimeClientIds = clients
+      .map(c => c.id)
+      .filter(cid => !clientsWithExistingMatches.has(cid));
+
     // 6. UPSERT matches in batches
     // Excludes is_new and first_matched_at from the payload so that:
     // - New rows get DB defaults: is_new=true, first_matched_at=NOW()
@@ -195,6 +204,18 @@ async function runMatchComputation(supabase, { trigger, scope }) {
         } else {
           newCount++;
         }
+      }
+    }
+
+    // 6b. For first-time clients, set is_new=false on all their matches.
+    // When a client is brand new, every match is "initial" — not a delta worth flagging.
+    if (firstTimeClientIds.length > 0) {
+      const { error: clearNewError } = await supabase
+        .from('client_matches')
+        .update({ is_new: false })
+        .in('client_id', firstTimeClientIds);
+      if (clearNewError) {
+        console.warn('[computeMatches] Failed to clear is_new for first-time clients:', clearNewError.message);
       }
     }
 

--- a/lib/matching/evaluateMatch.js
+++ b/lib/matching/evaluateMatch.js
@@ -1,0 +1,118 @@
+/**
+ * Shared client-opportunity matching module
+ *
+ * Single source of truth for the 4-criteria matching algorithm.
+ * Used by all client-matching API routes.
+ *
+ * Criteria (all must pass):
+ * 1. Location — coverage_area_ids intersection or is_national
+ * 2. Applicant Type — expanded types with normalizeType for plural tolerance
+ * 3. Project Needs — substring matching against eligible_project_types
+ * 4. Activities — must include at least one "hot" activity
+ *
+ * Score = percentage of client's project_needs that matched (0-100)
+ */
+
+/**
+ * Normalize a type string for matching comparison.
+ * Handles plurals, case, and common variations.
+ *
+ * @param {string} type - The type string to normalize
+ * @returns {string} Normalized type string
+ */
+export function normalizeType(type) {
+  if (!type) return '';
+  return type
+    .toLowerCase()
+    .trim()
+    .replace(/ies$/, 'y')              // agencies → agency, utilities → utility
+    .replace(/(ch|sh|ss|x|z)es$/, '$1') // churches → church, businesses → business
+    .replace(/s$/, '');                 // hospitals → hospital, governments → government
+}
+
+/**
+ * Evaluate if an opportunity matches a client using all 4 criteria.
+ *
+ * @param {Object} client - Client record with type, coverage_area_ids, project_needs
+ * @param {Object} opportunity - Opportunity with is_national, eligible_applicants, etc.
+ * @param {Object} deps - Injected dependencies
+ * @param {string[]} deps.hotActivities - List of hot activity strings
+ * @param {Function} deps.getExpandedClientTypes - Function to expand client type to synonyms/hierarchy
+ * @returns {{ isMatch: boolean, score: number, details: Object }}
+ */
+export function evaluateMatch(client, opportunity, { hotActivities, getExpandedClientTypes }) {
+  const details = {
+    locationMatch: false,
+    applicantTypeMatch: false,
+    projectNeedsMatch: false,
+    activitiesMatch: false,
+    matchedProjectNeeds: []
+  };
+
+  // 1. Location Match (using coverage_area_ids for precise geographic matching)
+  if (opportunity.is_national) {
+    details.locationMatch = true;
+  } else if (
+    client.coverage_area_ids && Array.isArray(client.coverage_area_ids) &&
+    opportunity.coverage_area_ids && Array.isArray(opportunity.coverage_area_ids)
+  ) {
+    details.locationMatch = client.coverage_area_ids.some(clientAreaId =>
+      opportunity.coverage_area_ids.includes(clientAreaId)
+    );
+  }
+
+  // 2. Applicant Type Match (with synonym/hierarchy expansion + normalizeType)
+  if (opportunity.eligible_applicants && Array.isArray(opportunity.eligible_applicants)) {
+    const expandedTypes = getExpandedClientTypes(client.type);
+    details.applicantTypeMatch = opportunity.eligible_applicants.some(applicant => {
+      const normalizedApplicant = normalizeType(applicant);
+      return expandedTypes.some(clientType => {
+        const normalizedClient = normalizeType(clientType);
+        return (
+          normalizedApplicant === normalizedClient ||
+          normalizedApplicant.includes(normalizedClient) ||
+          normalizedClient.includes(normalizedApplicant)
+        );
+      });
+    });
+  }
+
+  // 3. Project Needs Match
+  if (
+    opportunity.eligible_project_types && Array.isArray(opportunity.eligible_project_types) &&
+    client.project_needs && Array.isArray(client.project_needs)
+  ) {
+    for (const need of client.project_needs) {
+      const hasMatch = opportunity.eligible_project_types.some(projectType =>
+        projectType.toLowerCase().includes(need.toLowerCase()) ||
+        need.toLowerCase().includes(projectType.toLowerCase())
+      );
+      if (hasMatch) {
+        details.matchedProjectNeeds.push(need);
+      }
+    }
+    details.projectNeedsMatch = details.matchedProjectNeeds.length > 0;
+  }
+
+  // 4. Activities Match (must include at least one "hot" activity)
+  if (opportunity.eligible_activities && Array.isArray(opportunity.eligible_activities)) {
+    details.activitiesMatch = opportunity.eligible_activities.some(activity =>
+      hotActivities.some(hotActivity =>
+        activity.toLowerCase().includes(hotActivity.toLowerCase()) ||
+        hotActivity.toLowerCase().includes(activity.toLowerCase())
+      )
+    );
+  }
+
+  const isMatch = details.locationMatch &&
+                  details.applicantTypeMatch &&
+                  details.projectNeedsMatch &&
+                  details.activitiesMatch;
+
+  let score = 0;
+  if (isMatch && client.project_needs && client.project_needs.length > 0) {
+    score = Math.round((details.matchedProjectNeeds.length / client.project_needs.length) * 100);
+  }
+
+  return { isMatch, score, details };
+}

--- a/lib/services/processCoordinatorV2.js
+++ b/lib/services/processCoordinatorV2.js
@@ -35,6 +35,7 @@ import { updateDuplicateOpportunities } from '../agents-v2/optimization/directUp
 import { enhanceOpportunities } from '../agents-v2/core/analysisAgent/index.js';
 import { filterOpportunities } from '../agents-v2/core/filterFunction.js';
 import { storeOpportunities } from '../agents-v2/core/storageAgent/index.js';
+import { computeMatchesForOpportunities } from '../matching/computeMatches.js';
 import { RunManagerV2 } from './runManagerV2.js';
 import { initializeGlobalErrorHandlers, wrapWithErrorHandling, withTimeout } from '../utils/errorHandlers.js';
 import { retryStage, CircuitBreaker } from '../utils/retryHandler.js';
@@ -712,6 +713,15 @@ export async function processApiSourceV2(sourceId, runId = null, supabase, anthr
             path.finalOutcome = 'stored'
           }
         })
+
+        // Fire-and-forget: compute matches for newly stored opportunities
+        const storedIds = (storageResult.results?.newOpportunities || []).map(o => o.id).filter(Boolean)
+        if (storedIds.length > 0) {
+          computeMatchesForOpportunities(supabase, storedIds).catch(err =>
+            console.error('[ProcessCoordinatorV2] Background match computation failed:', err.message)
+          )
+          console.log(`[ProcessCoordinatorV2] 🔄 Match computation triggered for ${storedIds.length} new opportunities`)
+        }
       }
     } else {
       console.log(`[ProcessCoordinatorV2] ℹ️ No NEW opportunities to process through full pipeline`)

--- a/lib/utils/clientMatching.js
+++ b/lib/utils/clientMatching.js
@@ -4,6 +4,8 @@
  * Shared utilities for client-opportunity matching functionality
  */
 
+import { FUNDING_TYPE_GROUPS } from '@/lib/constants/taxonomies';
+
 /**
  * Fetch matches for a specific client or all clients
  */
@@ -105,6 +107,98 @@ export function generateClientTags(client, matches = [], limit = 3) {
   const limitedNeeds = limit ? sortedNeeds.slice(0, limit) : sortedNeeds;
 
   return limitedNeeds.map(([need, count]) => `${need} (${count})`);
+}
+
+/**
+ * Generate project needs with match counts (merged view)
+ * @param {Array} projectNeeds - Client's project_needs array
+ * @param {Array} matches - Array of match objects with matchDetails
+ * @returns {Array} Array of { need, count } objects
+ */
+export function generateProjectNeedsWithCounts(projectNeeds, matches = []) {
+  if (!projectNeeds || !Array.isArray(projectNeeds) || projectNeeds.length === 0) return [];
+
+  // Build match count map
+  const countMap = new Map();
+  if (Array.isArray(matches)) {
+    matches.forEach(match => {
+      const matchedNeeds = match.matchDetails?.matchedProjectNeeds || [];
+      matchedNeeds.forEach(need => {
+        countMap.set(need, (countMap.get(need) || 0) + 1);
+      });
+    });
+  }
+
+  return projectNeeds.map(need => ({
+    need,
+    count: countMap.get(need) || 0,
+  }));
+}
+
+/**
+ * Get relevance score from an opportunity, with fallbacks
+ */
+function getRelevanceScore(opportunity) {
+  return opportunity.relevance_score
+    || opportunity.scoring?.finalScore
+    || opportunity.scoring?.overallScore
+    || 0;
+}
+
+/**
+ * Group matches by funding type category, sorted by relevance within each group
+ * @param {Array} matches - Array of match/opportunity objects
+ * @returns {Array} Array of { key, label, description, matches } group objects (non-empty only)
+ */
+export function groupMatchesByFundingType(matches) {
+  if (!matches || !Array.isArray(matches) || matches.length === 0) return [];
+
+  // Build a lookup: funding type string → group index
+  const typeToGroup = new Map();
+  FUNDING_TYPE_GROUPS.forEach((group, index) => {
+    group.types.forEach(type => typeToGroup.set(type, index));
+  });
+
+  // Distribute matches into groups
+  const groups = FUNDING_TYPE_GROUPS.map(g => ({ ...g, matches: [] }));
+
+  matches.forEach(match => {
+    const fundingType = match.funding_type || '';
+    const groupIndex = typeToGroup.has(fundingType) ? typeToGroup.get(fundingType) : groups.length - 1;
+    groups[groupIndex].matches.push(match);
+  });
+
+  // Sort within each group by relevance_score descending
+  groups.forEach(group => {
+    group.matches.sort((a, b) => getRelevanceScore(b) - getRelevanceScore(a));
+  });
+
+  // Return only non-empty groups
+  return groups.filter(g => g.matches.length > 0);
+}
+
+/**
+ * Get match score badge inline styles (border-only pill style)
+ * Uses inline styles to avoid Tailwind JIT purging dynamic classes (e.g. violet-*)
+ */
+export function getMatchScoreBadgeStyles(score) {
+  if (score >= 60) return { backgroundColor: '#f5f3ff', color: '#6d28d9', border: '1px solid #c4b5fd' }; // violet-50/700/300
+  if (score >= 30) return { backgroundColor: '#fffbeb', color: '#b45309', border: '1px solid #fcd34d' }; // amber-50/700/300
+  return { backgroundColor: '#f9fafb', color: '#6b7280', border: '1px solid #d1d5db' }; // neutral-50/500/300
+}
+
+/**
+ * Get color for funding type group header dots (inline style to avoid Tailwind JIT issues)
+ */
+export function getFundingGroupDotColor(key) {
+  const colors = {
+    grants: '#10b981',      // emerald-500
+    incentives: '#8b5cf6',  // violet-500
+    tax: '#f59e0b',         // amber-500
+    loans: '#3b82f6',       // blue-500
+    other: '#a3a3a3',       // neutral-400
+  };
+  return colors[key] || colors.other;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "staging:cron": "node scripts/staging-cron.js",
     "staging:cron:once": "node scripts/staging-cron.js --max-empty=1",
     "staging:cron:fast": "node scripts/staging-cron.js --interval=30",
-    "build": "next build",
+    "build": "next build && node scripts/seed-matches.mjs",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run --config tests/vitest.config.js",

--- a/scripts/seed-matches.mjs
+++ b/scripts/seed-matches.mjs
@@ -1,0 +1,63 @@
+/**
+ * One-time build-time match seeder.
+ *
+ * Runs after `next build` to populate client_matches before the
+ * deployment goes live. Skips instantly if matches already exist.
+ *
+ * Remove this script (and the package.json build change) after
+ * first successful deployment to both staging and production.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { computeAllMatches } from '../lib/matching/computeMatches.js';
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SECRET_KEY;
+
+  if (!url || !key) {
+    console.log('[SeedMatches] Missing Supabase credentials, skipping');
+    return;
+  }
+
+  const supabase = createClient(url, key);
+
+  // Fast check: do matches already exist?
+  const { count, error: countError } = await supabase
+    .from('client_matches')
+    .select('id', { count: 'exact', head: true });
+
+  if (countError) {
+    console.warn('[SeedMatches] Could not check client_matches:', countError.message);
+    return;
+  }
+
+  if (count > 0) {
+    console.log(`[SeedMatches] ${count} matches already exist, skipping`);
+    return;
+  }
+
+  // Check if there are clients to match
+  const { count: clientCount, error: clientError } = await supabase
+    .from('clients')
+    .select('id', { count: 'exact', head: true });
+
+  if (clientError) {
+    console.warn('[SeedMatches] Could not check clients:', clientError.message);
+    return;
+  }
+
+  if (!clientCount) {
+    console.log('[SeedMatches] No clients found, skipping');
+    return;
+  }
+
+  console.log(`[SeedMatches] Seeding matches for ${clientCount} clients...`);
+  const stats = await computeAllMatches(supabase);
+  console.log('[SeedMatches] Complete:', JSON.stringify(stats));
+}
+
+main().catch(err => {
+  // Non-fatal: log and exit cleanly so build succeeds
+  console.warn('[SeedMatches] Non-fatal error:', err.message);
+});

--- a/supabase/migrations/20260304000001_create_client_matches_table.sql
+++ b/supabase/migrations/20260304000001_create_client_matches_table.sql
@@ -1,0 +1,44 @@
+-- Create client_matches table for persistent client-opportunity matching
+-- Replaces on-the-fly matching with stored results for delta detection and notifications
+
+CREATE TABLE IF NOT EXISTS client_matches (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id UUID NOT NULL REFERENCES clients(id) ON DELETE CASCADE,
+  opportunity_id UUID NOT NULL REFERENCES funding_opportunities(id) ON DELETE CASCADE,
+  score INTEGER NOT NULL DEFAULT 0,
+  match_details JSONB NOT NULL DEFAULT '{}'::jsonb,
+  first_matched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_matched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  is_new BOOLEAN NOT NULL DEFAULT true,
+  UNIQUE(client_id, opportunity_id)
+);
+
+-- Indexes for common query patterns
+CREATE INDEX IF NOT EXISTS idx_client_matches_client_id ON client_matches(client_id);
+CREATE INDEX IF NOT EXISTS idx_client_matches_opportunity_id ON client_matches(opportunity_id);
+
+-- RLS: same pattern as other tables
+ALTER TABLE client_matches ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'client_matches' AND policyname = 'authenticated_select'
+  ) THEN
+    CREATE POLICY "authenticated_select" ON client_matches FOR SELECT TO authenticated USING (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'client_matches' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON client_matches FOR ALL TO service_role USING (true);
+  END IF;
+END$$;
+
+-- Document that match_client_to_opportunities RPC is superseded
+-- The RPC only performs geographic matching (location criterion).
+-- The shared module lib/matching/evaluateMatch.js performs full 4-criteria matching
+-- (location + applicant type + project needs + activities) with scoring.
+-- The RPC is retained for backward compatibility.
+COMMENT ON FUNCTION match_client_to_opportunities(UUID) IS
+  'SUPERSEDED by client_matches table + lib/matching/evaluateMatch.js. This RPC only performs geographic matching. The shared module performs full 4-criteria matching with scoring. Retained for backward compatibility.';

--- a/supabase/migrations/20260305000001_add_match_job_support.sql
+++ b/supabase/migrations/20260305000001_add_match_job_support.sql
@@ -1,0 +1,59 @@
+-- Add stale tracking to client_matches and create job logging infrastructure
+-- Part of #38: Background match computation job with delta detection
+
+-- 1. Add stale tracking columns to client_matches
+ALTER TABLE client_matches ADD COLUMN IF NOT EXISTS is_stale BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE client_matches ADD COLUMN IF NOT EXISTS stale_at TIMESTAMPTZ;
+
+-- Index for filtering active (non-stale) matches
+CREATE INDEX IF NOT EXISTS idx_client_matches_active ON client_matches(client_id) WHERE is_stale = false;
+
+-- 2. Create match_job_logs table for observability
+CREATE TABLE IF NOT EXISTS match_job_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  trigger TEXT NOT NULL,           -- 'cron', 'opportunity_stored', 'client_created', 'client_updated'
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMPTZ,
+  status TEXT NOT NULL DEFAULT 'running',  -- 'running', 'completed', 'failed'
+  stats JSONB DEFAULT '{}'::jsonb, -- { clients_processed, opportunities_evaluated, new_matches, updated_matches, stale_matches, duration_ms }
+  error TEXT,
+  scope JSONB DEFAULT '{}'::jsonb  -- { client_ids: [...], opportunity_ids: [...] } for scoped runs
+);
+
+-- RLS: same pattern as client_matches
+ALTER TABLE match_job_logs ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'match_job_logs' AND policyname = 'authenticated_select'
+  ) THEN
+    CREATE POLICY "authenticated_select" ON match_job_logs FOR SELECT TO authenticated USING (true);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE tablename = 'match_job_logs' AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY "service_role_all" ON match_job_logs FOR ALL TO service_role USING (true);
+  END IF;
+END$$;
+
+-- 3. Enable pg_net for async HTTP calls from pg_cron
+CREATE EXTENSION IF NOT EXISTS pg_net WITH SCHEMA extensions;
+
+-- 4. Schedule daily match computation via pg_cron + pg_net
+-- Calls the Next.js API route asynchronously at 3 AM UTC daily.
+-- Requires app.site_url and app.cron_secret to be set as Postgres config parameters:
+--   ALTER DATABASE postgres SET app.site_url = 'https://your-app.vercel.app';
+--   ALTER DATABASE postgres SET app.cron_secret = 'your-cron-secret';
+SELECT cron.schedule(
+  'daily-match-computation',
+  '0 3 * * *',
+  $$
+  SELECT net.http_get(
+    url := current_setting('app.site_url') || '/api/cron/compute-matches',
+    headers := jsonb_build_object('Authorization', 'Bearer ' || current_setting('app.cron_secret')),
+    timeout_milliseconds := 30000
+  );
+  $$
+);

--- a/tests/api/client-matching.api.test.js
+++ b/tests/api/client-matching.api.test.js
@@ -13,22 +13,27 @@ import { opportunities } from '../fixtures/opportunities.js';
 
 /**
  * Expected match object shape
+ * Matches the output of transformMatch in app/api/client-matching/route.js:
+ * { ...opp, source_type, score, matchDetails, is_new, first_matched_at }
  */
 const matchSchema = {
-  opportunity_id: 'string',
-  opportunity_title: 'string',
+  id: 'string',
+  title: 'string',
   agency_name: 'string|null',
   score: 'number',
-  matching_criteria: 'object',
+  matchDetails: 'object',
   close_date: 'string|null',
   maximum_award: 'number|null',
   is_national: 'boolean',
+  source_type: 'string|null',
+  is_new: 'boolean',
+  first_matched_at: 'string|null',
 };
 
 /**
- * Expected matching criteria shape
+ * Expected matchDetails shape (camelCase, mapped from match_details in client_matches)
  */
-const matchingCriteriaSchema = {
+const matchDetailsSchema = {
   locationMatch: 'boolean',
   applicantTypeMatch: 'boolean',
   projectNeedsMatch: 'boolean',
@@ -81,11 +86,11 @@ describe('Client Matching API Contract', () => {
   describe('Match Schema', () => {
     test('validates complete match object', () => {
       const match = {
-        opportunity_id: 'opp-123',
-        opportunity_title: 'Clean Energy Grant',
+        id: 'opp-123',
+        title: 'Clean Energy Grant',
         agency_name: 'DOE',
         score: 85,
-        matching_criteria: {
+        matchDetails: {
           locationMatch: true,
           applicantTypeMatch: true,
           projectNeedsMatch: true,
@@ -94,6 +99,9 @@ describe('Client Matching API Contract', () => {
         close_date: '2025-06-30T23:59:59Z',
         maximum_award: 5000000,
         is_national: true,
+        source_type: 'federal',
+        is_new: true,
+        first_matched_at: '2025-06-01T00:00:00Z',
       };
 
       const errors = validateSchema(match, matchSchema);
@@ -102,11 +110,11 @@ describe('Client Matching API Contract', () => {
 
     test('validates match with null optional fields', () => {
       const match = {
-        opportunity_id: 'opp-123',
-        opportunity_title: 'Minimal Grant',
+        id: 'opp-123',
+        title: 'Minimal Grant',
         agency_name: null,
         score: 50,
-        matching_criteria: {
+        matchDetails: {
           locationMatch: true,
           applicantTypeMatch: false,
           projectNeedsMatch: true,
@@ -115,6 +123,9 @@ describe('Client Matching API Contract', () => {
         close_date: null,
         maximum_award: null,
         is_national: false,
+        source_type: null,
+        is_new: false,
+        first_matched_at: null,
       };
 
       const errors = validateSchema(match, matchSchema);
@@ -123,14 +134,17 @@ describe('Client Matching API Contract', () => {
 
     test('score must be a number', () => {
       const match = {
-        opportunity_id: 'opp-123',
-        opportunity_title: 'Grant',
+        id: 'opp-123',
+        title: 'Grant',
         agency_name: null,
         score: 'high', // Invalid
-        matching_criteria: {},
+        matchDetails: {},
         close_date: null,
         maximum_award: null,
         is_national: false,
+        source_type: null,
+        is_new: false,
+        first_matched_at: null,
       };
 
       const errors = validateSchema(match, matchSchema);
@@ -138,7 +152,7 @@ describe('Client Matching API Contract', () => {
     });
   });
 
-  describe('Matching Criteria Schema', () => {
+  describe('Match Details Schema', () => {
     test('validates all boolean criteria', () => {
       const criteria = {
         locationMatch: true,
@@ -147,7 +161,7 @@ describe('Client Matching API Contract', () => {
         activitiesMatch: true,
       };
 
-      const errors = validateSchema(criteria, matchingCriteriaSchema);
+      const errors = validateSchema(criteria, matchDetailsSchema);
       expect(errors).toHaveLength(0);
     });
 
@@ -158,51 +172,78 @@ describe('Client Matching API Contract', () => {
         // missing projectNeedsMatch and activitiesMatch
       };
 
-      const errors = validateSchema(incompleteCriteria, matchingCriteriaSchema);
+      const errors = validateSchema(incompleteCriteria, matchDetailsSchema);
       expect(errors.length).toBeGreaterThan(0);
     });
   });
 
   describe('List Response Shape', () => {
-    test('validates matches array response', () => {
-      const response = {
-        client_id: 'client-123',
-        client_name: 'City of SF',
-        matches: [
-          {
-            opportunity_id: 'opp-1',
-            opportunity_title: 'Grant 1',
-            agency_name: 'DOE',
-            score: 90,
-            matching_criteria: {
-              locationMatch: true,
-              applicantTypeMatch: true,
-              projectNeedsMatch: true,
-              activitiesMatch: true,
-            },
-            close_date: '2025-06-30',
-            maximum_award: 1000000,
-            is_national: true,
-          },
-        ],
-        total_matches: 1,
+    // Inline version of the single-client response shape from route.js handleSingleClient
+    function buildSingleClientResponse(client, matches, hiddenCount) {
+      return {
+        success: true,
+        results: {
+          client,
+          matches,
+          matchCount: matches.length,
+          hiddenCount,
+          topMatches: matches.slice(0, 3)
+        },
+        timestamp: new Date().toISOString()
       };
+    }
 
-      expect(Array.isArray(response.matches)).toBe(true);
-      expect(response.total_matches).toBe(1);
-      expect(response.client_id).toBe('client-123');
+    test('validates single-client response shape', () => {
+      const client = { id: 'client-123', name: 'City of SF' };
+      const matches = [
+        {
+          id: 'opp-1',
+          title: 'Grant 1',
+          agency_name: 'DOE',
+          score: 90,
+          matchDetails: {
+            locationMatch: true,
+            applicantTypeMatch: true,
+            projectNeedsMatch: true,
+            activitiesMatch: true,
+          },
+          close_date: '2025-06-30',
+          maximum_award: 1000000,
+          is_national: true,
+          source_type: 'federal',
+          is_new: true,
+          first_matched_at: '2025-06-01T00:00:00Z',
+        },
+      ];
+
+      const response = buildSingleClientResponse(client, matches, 0);
+      expect(response.success).toBe(true);
+      expect(Array.isArray(response.results.matches)).toBe(true);
+      expect(response.results.matchCount).toBe(1);
+      expect(response.results.client.id).toBe('client-123');
+      expect(response.results.topMatches).toHaveLength(1);
+      expect(response.timestamp).toBeDefined();
     });
 
     test('empty matches array is valid', () => {
-      const response = {
-        client_id: 'client-123',
-        client_name: 'New Client',
-        matches: [],
-        total_matches: 0,
-      };
+      const client = { id: 'client-123', name: 'New Client' };
+      const response = buildSingleClientResponse(client, [], 0);
 
-      expect(response.matches).toHaveLength(0);
-      expect(response.total_matches).toBe(0);
+      expect(response.results.matches).toHaveLength(0);
+      expect(response.results.matchCount).toBe(0);
+      expect(response.results.hiddenCount).toBe(0);
+    });
+
+    test('topMatches limited to 3', () => {
+      const client = { id: 'client-123', name: 'City of SF' };
+      const matches = Array.from({ length: 5 }, (_, i) => ({
+        id: `opp-${i}`, title: `Grant ${i}`, score: 90 - i * 5
+      }));
+      const response = buildSingleClientResponse(client, matches, 2);
+
+      expect(response.results.matchCount).toBe(5);
+      expect(response.results.topMatches).toHaveLength(3);
+      expect(response.results.hiddenCount).toBe(2);
     });
   });
 
@@ -239,7 +280,7 @@ describe('Client Matching API Contract', () => {
 
   describe('Promotion Status Filter (opportunity visibility)', () => {
     // Inline filter replicating: .neq('status', 'closed').or('promotion_status.is.null,promotion_status.eq.promoted')
-    // Used by client-matching, top-matches, and summary routes
+    // Used by lib/matching/computeMatches.js when fetching opportunities for match computation
     function filterVisibleOpportunities(opps) {
       return opps.filter(
         (o) =>
@@ -298,6 +339,143 @@ describe('Client Matching API Contract', () => {
       expect(visible).toHaveLength(2);
       expect(visibleIds).toContain('vis-1');
       expect(visibleIds).toContain('vis-2');
+    });
+  });
+
+  describe('is_new Field (from client_matches)', () => {
+    test('match object can include is_new boolean', () => {
+      const match = {
+        id: 'opp-123',
+        title: 'New Grant',
+        agency_name: 'DOE',
+        score: 85,
+        matchDetails: {
+          locationMatch: true,
+          applicantTypeMatch: true,
+          projectNeedsMatch: true,
+          activitiesMatch: true,
+        },
+        close_date: '2025-06-30',
+        maximum_award: 5000000,
+        is_national: true,
+        source_type: 'federal',
+        is_new: true,
+        first_matched_at: '2025-06-01T00:00:00Z',
+      };
+
+      expect(typeof match.is_new).toBe('boolean');
+      expect(match.is_new).toBe(true);
+    });
+
+    test('is_new defaults to true for new matches', () => {
+      const newMatch = { is_new: true };
+      const seenMatch = { is_new: false };
+      expect(newMatch.is_new).toBe(true);
+      expect(seenMatch.is_new).toBe(false);
+    });
+  });
+
+  describe('Match Transform (client_matches row to API shape)', () => {
+    // Inline version of transformMatch from the route
+    function transformMatch(row) {
+      const opp = row.opportunity;
+      return {
+        ...opp,
+        source_type: opp.funding_sources?.type || null,
+        funding_sources: undefined,
+        score: row.score,
+        matchDetails: row.match_details,
+        is_new: row.is_new,
+        first_matched_at: row.first_matched_at
+      };
+    }
+
+    test('maps match_details to matchDetails (camelCase)', () => {
+      const row = {
+        score: 75,
+        match_details: {
+          locationMatch: true,
+          applicantTypeMatch: true,
+          projectNeedsMatch: true,
+          activitiesMatch: true,
+          matchedProjectNeeds: ['Solar Installation']
+        },
+        is_new: true,
+        first_matched_at: '2025-06-01T00:00:00Z',
+        opportunity: {
+          id: 'opp-1',
+          title: 'Solar Grant',
+          agency_name: 'DOE',
+          funding_sources: { type: 'federal' }
+        }
+      };
+
+      const result = transformMatch(row);
+      expect(result.matchDetails).toEqual(row.match_details);
+      expect(result.matchDetails.matchedProjectNeeds).toEqual(['Solar Installation']);
+      expect(result.score).toBe(75);
+      expect(result.is_new).toBe(true);
+      expect(result.first_matched_at).toBe('2025-06-01T00:00:00Z');
+      expect(result.source_type).toBe('federal');
+      expect(result.funding_sources).toBeUndefined();
+    });
+
+    test('handles null funding_sources gracefully', () => {
+      const row = {
+        score: 50,
+        match_details: {},
+        is_new: false,
+        first_matched_at: '2025-05-15T00:00:00Z',
+        opportunity: {
+          id: 'opp-2',
+          title: 'State Grant',
+          funding_sources: null
+        }
+      };
+
+      const result = transformMatch(row);
+      expect(result.source_type).toBeNull();
+      expect(result.first_matched_at).toBe('2025-05-15T00:00:00Z');
+    });
+  });
+
+  describe('Hidden Match Filtering (query-time)', () => {
+    // Inline version of the hidden matches filtering logic
+    function filterHiddenMatches(matchRows, hiddenIds) {
+      const hiddenSet = new Set(hiddenIds);
+      return matchRows.filter(row => !hiddenSet.has(row.opportunity_id));
+    }
+
+    test('excludes hidden opportunity IDs', () => {
+      const rows = [
+        { opportunity_id: 'opp-1', score: 90 },
+        { opportunity_id: 'opp-2', score: 80 },
+        { opportunity_id: 'opp-3', score: 70 },
+      ];
+      const hidden = ['opp-2'];
+
+      const visible = filterHiddenMatches(rows, hidden);
+      expect(visible).toHaveLength(2);
+      expect(visible.map(r => r.opportunity_id)).toEqual(['opp-1', 'opp-3']);
+    });
+
+    test('returns all when no hidden matches', () => {
+      const rows = [
+        { opportunity_id: 'opp-1', score: 90 },
+        { opportunity_id: 'opp-2', score: 80 },
+      ];
+
+      const visible = filterHiddenMatches(rows, []);
+      expect(visible).toHaveLength(2);
+    });
+
+    test('returns empty when all hidden', () => {
+      const rows = [
+        { opportunity_id: 'opp-1', score: 90 },
+      ];
+
+      const visible = filterHiddenMatches(rows, ['opp-1']);
+      expect(visible).toHaveLength(0);
     });
   });
 
@@ -571,6 +749,55 @@ describe('Client Matching API Contract', () => {
 
       expect(response.success).toBe(false);
       expect(response.error).toContain('opportunityId');
+    });
+  });
+
+  describe('POST /api/client-matching/mark-seen Response', () => {
+    // Inline version of input validation from mark-seen/route.js
+    function validateMarkSeenInput(body) {
+      if (!body || !body.clientId) {
+        return { valid: false, error: 'clientId is required', status: 400 };
+      }
+      return { valid: true };
+    }
+
+    // Inline version of response building from mark-seen/route.js
+    function buildMarkSeenResponse(dbError) {
+      if (dbError) {
+        return { body: { error: 'Failed to mark matches as seen' }, status: 500 };
+      }
+      return { body: { success: true }, status: 200 };
+    }
+
+    test('valid clientId passes validation', () => {
+      const result = validateMarkSeenInput({ clientId: 'client-123' });
+      expect(result.valid).toBe(true);
+    });
+
+    test('missing clientId fails validation with 400', () => {
+      const result = validateMarkSeenInput({});
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('clientId is required');
+      expect(result.status).toBe(400);
+    });
+
+    test('null body fails validation with 400', () => {
+      const result = validateMarkSeenInput(null);
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('clientId is required');
+      expect(result.status).toBe(400);
+    });
+
+    test('successful DB update returns success', () => {
+      const response = buildMarkSeenResponse(null);
+      expect(response.body.success).toBe(true);
+      expect(response.status).toBe(200);
+    });
+
+    test('DB error returns 500', () => {
+      const response = buildMarkSeenResponse({ message: 'DB connection failed' });
+      expect(response.body.error).toBe('Failed to mark matches as seen');
+      expect(response.status).toBe(500);
     });
   });
 });

--- a/tests/api/cron-compute-matches.api.test.js
+++ b/tests/api/cron-compute-matches.api.test.js
@@ -1,0 +1,193 @@
+/**
+ * Cron Compute Matches API Contract Tests
+ *
+ * Validates auth logic, response shapes, and trigger classification
+ * for GET /api/cron/compute-matches and POST /api/cron/compute-matches.
+ */
+
+import { describe, test, expect } from 'vitest';
+
+// --- Inline functions mirroring route logic ---
+
+/**
+ * Verify auth for a cron request.
+ * Returns { ok: true } if valid, or { ok: false, status, error } if not.
+ */
+function verifyAuth(authHeader, cronSecret) {
+  if (!cronSecret) {
+    return { ok: false, status: 500, error: 'Server misconfigured' };
+  }
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return { ok: false, status: 401, error: 'Unauthorized' };
+  }
+  return { ok: true };
+}
+
+/**
+ * Determine trigger type from POST body.
+ */
+function classifyManualTrigger(body) {
+  if (body.clientId) return 'manual_client';
+  if (body.opportunityIds?.length) return 'manual_opportunities';
+  return 'manual_full';
+}
+
+/**
+ * Validate cron response shape.
+ */
+const cronResponseSchema = {
+  success: 'boolean',
+  trigger: 'string',
+  timestamp: 'string',
+  executionTimeMs: 'number'
+};
+
+const errorResponseSchema = {
+  success: 'boolean',
+  error: 'string',
+  timestamp: 'string',
+  executionTimeMs: 'number'
+};
+
+function validateSchema(obj, schema) {
+  const errors = [];
+  for (const [field, expectedType] of Object.entries(schema)) {
+    if (!(field in obj)) {
+      errors.push(`Missing required field: ${field}`);
+    } else if (typeof obj[field] !== expectedType) {
+      errors.push(`Field ${field}: expected ${expectedType}, got ${typeof obj[field]}`);
+    }
+  }
+  return errors;
+}
+
+// --- Tests ---
+
+describe('Cron Compute Matches: Auth', () => {
+  test('valid Bearer token is accepted', () => {
+    const result = verifyAuth('Bearer my-secret-123', 'my-secret-123');
+    expect(result.ok).toBe(true);
+  });
+
+  test('missing Bearer token is rejected with 401', () => {
+    const result = verifyAuth(null, 'my-secret-123');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+  });
+
+  test('wrong Bearer token is rejected with 401', () => {
+    const result = verifyAuth('Bearer wrong-token', 'my-secret-123');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+  });
+
+  test('missing CRON_SECRET env var returns 500', () => {
+    const result = verifyAuth('Bearer anything', undefined);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(500);
+    expect(result.error).toBe('Server misconfigured');
+  });
+
+  test('empty CRON_SECRET env var returns 500', () => {
+    const result = verifyAuth('Bearer anything', '');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(500);
+  });
+
+  test('Bearer prefix is required', () => {
+    const result = verifyAuth('my-secret-123', 'my-secret-123');
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+  });
+});
+
+describe('Cron Compute Matches: Trigger Classification', () => {
+  test('body with clientId is manual_client', () => {
+    expect(classifyManualTrigger({ clientId: 'abc-123' })).toBe('manual_client');
+  });
+
+  test('body with opportunityIds is manual_opportunities', () => {
+    expect(classifyManualTrigger({ opportunityIds: ['o1', 'o2'] })).toBe('manual_opportunities');
+  });
+
+  test('empty body is manual_full', () => {
+    expect(classifyManualTrigger({})).toBe('manual_full');
+  });
+
+  test('clientId takes precedence over opportunityIds', () => {
+    expect(classifyManualTrigger({
+      clientId: 'abc',
+      opportunityIds: ['o1']
+    })).toBe('manual_client');
+  });
+
+  test('empty opportunityIds array is manual_full', () => {
+    expect(classifyManualTrigger({ opportunityIds: [] })).toBe('manual_full');
+  });
+});
+
+describe('Cron Compute Matches: Response Shape', () => {
+  test('success response has required fields', () => {
+    const response = {
+      success: true,
+      trigger: 'cron',
+      stats: { new_matches: 5 },
+      timestamp: new Date().toISOString(),
+      executionTimeMs: 123
+    };
+    const errors = validateSchema(response, cronResponseSchema);
+    expect(errors).toHaveLength(0);
+  });
+
+  test('success response includes stats object', () => {
+    const response = {
+      success: true,
+      trigger: 'manual_full',
+      stats: { clients_processed: 10, new_matches: 3 },
+      timestamp: new Date().toISOString(),
+      executionTimeMs: 456
+    };
+    expect(response.stats).toBeDefined();
+    expect(typeof response.stats).toBe('object');
+  });
+
+  test('error response has required fields', () => {
+    const response = {
+      success: false,
+      error: 'Something went wrong',
+      timestamp: new Date().toISOString(),
+      executionTimeMs: 50
+    };
+    const errors = validateSchema(response, errorResponseSchema);
+    expect(errors).toHaveLength(0);
+  });
+
+  test('error response has success=false', () => {
+    const response = {
+      success: false,
+      error: 'Failed to fetch clients',
+      timestamp: new Date().toISOString(),
+      executionTimeMs: 10
+    };
+    expect(response.success).toBe(false);
+    expect(response.error).toBeDefined();
+  });
+
+  test('GET trigger is always cron', () => {
+    const response = {
+      success: true,
+      trigger: 'cron',
+      stats: {},
+      timestamp: new Date().toISOString(),
+      executionTimeMs: 100
+    };
+    expect(response.trigger).toBe('cron');
+  });
+
+  test('POST trigger varies by body', () => {
+    const triggers = ['manual_full', 'manual_client', 'manual_opportunities'];
+    for (const trigger of triggers) {
+      expect(triggers).toContain(trigger);
+    }
+  });
+});

--- a/tests/critical/client-matching/clientMatchingUtils.test.js
+++ b/tests/critical/client-matching/clientMatchingUtils.test.js
@@ -542,3 +542,411 @@ describe('generateClientTags', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// New inline pure functions — added for match page redesign
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate project needs with match counts (merged view)
+ * (Logic from clientMatching.js:generateProjectNeedsWithCounts)
+ */
+function generateProjectNeedsWithCounts(projectNeeds, matches = []) {
+  if (!projectNeeds || !Array.isArray(projectNeeds) || projectNeeds.length === 0) return [];
+
+  const countMap = new Map();
+  if (Array.isArray(matches)) {
+    matches.forEach(match => {
+      const matchedNeeds = match.matchDetails?.matchedProjectNeeds || [];
+      matchedNeeds.forEach(need => {
+        countMap.set(need, (countMap.get(need) || 0) + 1);
+      });
+    });
+  }
+
+  return projectNeeds.map(need => ({
+    need,
+    count: countMap.get(need) || 0,
+  }));
+}
+
+/**
+ * Funding type group definitions, ordered by desirability
+ * (Logic from clientMatching.js:FUNDING_TYPE_GROUPS)
+ */
+const FUNDING_TYPE_GROUPS = [
+  {
+    key: 'grants',
+    label: 'Grants',
+    description: 'Direct Grant Funding',
+    types: ['Grant', 'Cooperative Agreement'],
+  },
+  {
+    key: 'tax',
+    label: 'Tax Benefits',
+    description: 'Tax Incentives',
+    types: ['Tax Credit', 'Tax Incentive', 'Tax Deduction', 'Tax Exemption'],
+  },
+  {
+    key: 'loans',
+    label: 'Loans',
+    description: 'Loans & Credit',
+    types: ['Loan', 'Forgivable Loan', 'Guarantee', 'Bond'],
+  },
+  {
+    key: 'incentives',
+    label: 'Rebates & Incentives',
+    description: 'Utility Incentives',
+    types: ['Rebate', 'Direct Payment', 'Voucher'],
+  },
+  {
+    key: 'other',
+    label: 'Other',
+    description: 'Support & Services',
+    types: [],
+  },
+];
+
+function getRelevanceScore(opportunity) {
+  return opportunity.relevance_score
+    || opportunity.scoring?.finalScore
+    || opportunity.scoring?.overallScore
+    || 0;
+}
+
+/**
+ * Group matches by funding type category
+ * (Logic from clientMatching.js:groupMatchesByFundingType)
+ */
+function groupMatchesByFundingType(matches) {
+  if (!matches || !Array.isArray(matches) || matches.length === 0) return [];
+
+  const typeToGroup = new Map();
+  FUNDING_TYPE_GROUPS.forEach((group, index) => {
+    group.types.forEach(type => typeToGroup.set(type, index));
+  });
+
+  const groups = FUNDING_TYPE_GROUPS.map(g => ({ ...g, matches: [] }));
+
+  matches.forEach(match => {
+    const fundingType = match.funding_type || '';
+    const groupIndex = typeToGroup.has(fundingType) ? typeToGroup.get(fundingType) : groups.length - 1;
+    groups[groupIndex].matches.push(match);
+  });
+
+  groups.forEach(group => {
+    group.matches.sort((a, b) => getRelevanceScore(b) - getRelevanceScore(a));
+  });
+
+  return groups.filter(g => g.matches.length > 0);
+}
+
+/**
+ * Get match score badge inline styles
+ * (Logic from clientMatching.js:getMatchScoreBadgeStyles)
+ */
+function getMatchScoreBadgeStyles(score) {
+  if (score >= 60) return { backgroundColor: '#f5f3ff', color: '#6d28d9', border: '1px solid #c4b5fd' };
+  if (score >= 30) return { backgroundColor: '#fffbeb', color: '#b45309', border: '1px solid #fcd34d' };
+  return { backgroundColor: '#f9fafb', color: '#6b7280', border: '1px solid #d1d5db' };
+}
+
+/**
+ * Get funding group dot color
+ * (Logic from clientMatching.js:getFundingGroupDotColor)
+ */
+function getFundingGroupDotColor(key) {
+  const colors = {
+    grants: '#10b981',
+    incentives: '#8b5cf6',
+    tax: '#f59e0b',
+    loans: '#3b82f6',
+    other: '#a3a3a3',
+  };
+  return colors[key] || colors.other;
+}
+
+/**
+ * Budget display formatting
+ * (Logic from matches/page.jsx budget formatting)
+ */
+function formatBudgetDisplay(budget) {
+  const budgetLabels = {
+    small: 'Small ($50K - $500K)',
+    medium: 'Medium ($500K - $5M)',
+    large: 'Large ($5M - $50M)',
+    very_large: 'Very Large ($50M+)',
+  };
+  return budgetLabels[budget]
+    || (typeof budget === 'number'
+      ? `$${budget.toLocaleString()}`
+      : (typeof budget === 'string' && budget !== '' && !isNaN(Number(budget))
+        ? `$${Number(budget).toLocaleString()}`
+        : budget || 'Not specified'));
+}
+
+// ---------------------------------------------------------------------------
+// Tests — New functions
+// ---------------------------------------------------------------------------
+
+describe('generateProjectNeedsWithCounts', () => {
+  function buildMatch(matchedProjectNeeds) {
+    return { matchDetails: { matchedProjectNeeds } };
+  }
+
+  test('returns needs with zero counts when no matches', () => {
+    const result = generateProjectNeedsWithCounts(['Solar', 'HVAC'], []);
+    expect(result).toEqual([
+      { need: 'Solar', count: 0 },
+      { need: 'HVAC', count: 0 },
+    ]);
+  });
+
+  test('counts matched needs correctly', () => {
+    const matches = [
+      buildMatch(['Solar', 'HVAC']),
+      buildMatch(['Solar']),
+    ];
+    const result = generateProjectNeedsWithCounts(['Solar', 'HVAC', 'Wind'], matches);
+    expect(result).toEqual([
+      { need: 'Solar', count: 2 },
+      { need: 'HVAC', count: 1 },
+      { need: 'Wind', count: 0 },
+    ]);
+  });
+
+  test('preserves project needs order', () => {
+    const matches = [buildMatch(['Z', 'A'])];
+    const result = generateProjectNeedsWithCounts(['A', 'Z'], matches);
+    expect(result[0].need).toBe('A');
+    expect(result[1].need).toBe('Z');
+  });
+
+  test('returns empty array for null projectNeeds', () => {
+    expect(generateProjectNeedsWithCounts(null, [])).toEqual([]);
+  });
+
+  test('returns empty array for empty projectNeeds', () => {
+    expect(generateProjectNeedsWithCounts([], [])).toEqual([]);
+  });
+
+  test('handles matches with no matchDetails', () => {
+    const matches = [{ matchDetails: null }, {}];
+    const result = generateProjectNeedsWithCounts(['Solar'], matches);
+    expect(result).toEqual([{ need: 'Solar', count: 0 }]);
+  });
+});
+
+describe('groupMatchesByFundingType', () => {
+  test('returns empty array for null/empty matches', () => {
+    expect(groupMatchesByFundingType(null)).toEqual([]);
+    expect(groupMatchesByFundingType([])).toEqual([]);
+    expect(groupMatchesByFundingType(undefined)).toEqual([]);
+  });
+
+  test('groups grants correctly', () => {
+    const matches = [
+      { funding_type: 'Grant', relevance_score: 8 },
+      { funding_type: 'Cooperative Agreement', relevance_score: 6 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('grants');
+    expect(groups[0].matches).toHaveLength(2);
+  });
+
+  test('groups rebates/incentives correctly', () => {
+    const matches = [
+      { funding_type: 'Rebate', relevance_score: 7 },
+      { funding_type: 'Direct Payment', relevance_score: 5 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('incentives');
+    expect(groups[0].matches).toHaveLength(2);
+  });
+
+  test('groups tax benefits correctly', () => {
+    const matches = [
+      { funding_type: 'Tax Credit', relevance_score: 7 },
+      { funding_type: 'Tax Exemption', relevance_score: 9 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('tax');
+    expect(groups[0].matches).toHaveLength(2);
+  });
+
+  test('groups loans correctly', () => {
+    const matches = [
+      { funding_type: 'Loan', relevance_score: 5 },
+      { funding_type: 'Forgivable Loan', relevance_score: 8 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('loans');
+  });
+
+  test('unknown funding types go to "other"', () => {
+    const matches = [
+      { funding_type: 'Technical Assistance', relevance_score: 4 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('other');
+  });
+
+  test('multiple groups returned in order: grants → tax → loans → incentives', () => {
+    const matches = [
+      { funding_type: 'Tax Credit', relevance_score: 7 },
+      { funding_type: 'Grant', relevance_score: 9 },
+      { funding_type: 'Loan', relevance_score: 5 },
+      { funding_type: 'Rebate', relevance_score: 4 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(4);
+    expect(groups[0].key).toBe('grants');
+    expect(groups[1].key).toBe('tax');
+    expect(groups[2].key).toBe('loans');
+    expect(groups[3].key).toBe('incentives');
+  });
+
+  test('empty groups are excluded', () => {
+    const matches = [{ funding_type: 'Grant', relevance_score: 8 }];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe('grants');
+  });
+
+  test('matches within a group are sorted by relevance score descending', () => {
+    const matches = [
+      { funding_type: 'Grant', relevance_score: 3 },
+      { funding_type: 'Grant', relevance_score: 9 },
+      { funding_type: 'Grant', relevance_score: 6 },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups[0].matches[0].relevance_score).toBe(9);
+    expect(groups[0].matches[1].relevance_score).toBe(6);
+    expect(groups[0].matches[2].relevance_score).toBe(3);
+  });
+
+  test('uses scoring.finalScore as fallback for relevance', () => {
+    const matches = [
+      { funding_type: 'Grant', scoring: { finalScore: 4 } },
+      { funding_type: 'Grant', scoring: { finalScore: 8 } },
+    ];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups[0].matches[0].scoring.finalScore).toBe(8);
+    expect(groups[0].matches[1].scoring.finalScore).toBe(4);
+  });
+
+  test('missing funding_type goes to other', () => {
+    const matches = [{ relevance_score: 5 }];
+    const groups = groupMatchesByFundingType(matches);
+    expect(groups[0].key).toBe('other');
+  });
+});
+
+describe('getMatchScoreBadgeStyles', () => {
+  test('60+ returns violet style', () => {
+    const style = getMatchScoreBadgeStyles(60);
+    expect(style.backgroundColor).toBe('#f5f3ff');
+    expect(style.color).toBe('#6d28d9');
+    expect(style.border).toContain('#c4b5fd');
+  });
+
+  test('100 returns violet style', () => {
+    expect(getMatchScoreBadgeStyles(100).color).toBe('#6d28d9');
+  });
+
+  test('30-59 returns amber style', () => {
+    const style = getMatchScoreBadgeStyles(30);
+    expect(style.backgroundColor).toBe('#fffbeb');
+    expect(style.color).toBe('#b45309');
+    expect(style.border).toContain('#fcd34d');
+  });
+
+  test('59 returns amber (boundary)', () => {
+    expect(getMatchScoreBadgeStyles(59).color).toBe('#b45309');
+  });
+
+  test('<30 returns neutral style', () => {
+    const style = getMatchScoreBadgeStyles(0);
+    expect(style.backgroundColor).toBe('#f9fafb');
+    expect(style.color).toBe('#6b7280');
+    expect(style.border).toContain('#d1d5db');
+  });
+
+  test('29 is neutral, 30 is amber (boundary)', () => {
+    expect(getMatchScoreBadgeStyles(29).color).toBe('#6b7280');
+    expect(getMatchScoreBadgeStyles(30).color).toBe('#b45309');
+  });
+
+  test('always returns object with 3 keys', () => {
+    [0, 15, 29, 30, 59, 60, 100].forEach(score => {
+      const style = getMatchScoreBadgeStyles(score);
+      expect(style).toHaveProperty('backgroundColor');
+      expect(style).toHaveProperty('color');
+      expect(style).toHaveProperty('border');
+    });
+  });
+});
+
+describe('getFundingGroupDotColor', () => {
+  test('grants returns emerald hex', () => {
+    expect(getFundingGroupDotColor('grants')).toBe('#10b981');
+  });
+
+  test('incentives returns violet hex', () => {
+    expect(getFundingGroupDotColor('incentives')).toBe('#8b5cf6');
+  });
+
+  test('tax returns amber hex', () => {
+    expect(getFundingGroupDotColor('tax')).toBe('#f59e0b');
+  });
+
+  test('loans returns blue hex', () => {
+    expect(getFundingGroupDotColor('loans')).toBe('#3b82f6');
+  });
+
+  test('other returns neutral hex', () => {
+    expect(getFundingGroupDotColor('other')).toBe('#a3a3a3');
+  });
+
+  test('unknown key returns other color', () => {
+    expect(getFundingGroupDotColor('unknown')).toBe('#a3a3a3');
+  });
+});
+
+describe('formatBudgetDisplay', () => {
+  test('label key returns human-readable label', () => {
+    expect(formatBudgetDisplay('small')).toBe('Small ($50K - $500K)');
+    expect(formatBudgetDisplay('medium')).toBe('Medium ($500K - $5M)');
+    expect(formatBudgetDisplay('large')).toBe('Large ($5M - $50M)');
+    expect(formatBudgetDisplay('very_large')).toBe('Very Large ($50M+)');
+  });
+
+  test('numeric budget is formatted with commas', () => {
+    expect(formatBudgetDisplay(30000000)).toBe('$30,000,000');
+    expect(formatBudgetDisplay(500000)).toBe('$500,000');
+    expect(formatBudgetDisplay(0)).toBe('$0');
+  });
+
+  test('string numeric budget is formatted', () => {
+    expect(formatBudgetDisplay('30000000')).toBe('$30,000,000');
+    expect(formatBudgetDisplay('500000')).toBe('$500,000');
+  });
+
+  test('non-numeric string passes through', () => {
+    expect(formatBudgetDisplay('custom budget')).toBe('custom budget');
+  });
+
+  test('null/undefined returns "Not specified"', () => {
+    expect(formatBudgetDisplay(null)).toBe('Not specified');
+    expect(formatBudgetDisplay(undefined)).toBe('Not specified');
+  });
+
+  test('empty string returns "Not specified"', () => {
+    expect(formatBudgetDisplay('')).toBe('Not specified');
+  });
+});

--- a/tests/critical/client-matching/deltaDetection.test.js
+++ b/tests/critical/client-matching/deltaDetection.test.js
@@ -1,0 +1,266 @@
+/**
+ * Delta Detection Tests
+ *
+ * Tests the logic that determines whether a match is new, updated, or stale
+ * when comparing computed matches against existing persisted matches.
+ *
+ * Mirrors the delta detection logic in lib/matching/computeMatches.js
+ */
+
+import { describe, test, expect } from 'vitest';
+
+// --- Inline functions mirroring computeMatches.js delta detection logic ---
+
+/**
+ * Classify a computed match as 'new' or 'updated' based on existing matches.
+ *
+ * @param {string} clientId
+ * @param {string} opportunityId
+ * @param {Set<string>} existingMatchKeys - Set of "clientId:opportunityId" strings
+ * @returns {'new' | 'updated'}
+ */
+function classifyMatch(clientId, opportunityId, existingMatchKeys) {
+  const key = `${clientId}:${opportunityId}`;
+  return existingMatchKeys.has(key) ? 'updated' : 'new';
+}
+
+/**
+ * Find stale matches: existed before but not in current computation.
+ *
+ * @param {Array<{client_id: string, opportunity_id: string}>} existingMatches
+ * @param {Set<string>} computedMatchKeys - Set of "clientId:opportunityId" strings
+ * @returns {Array<{client_id: string, opportunity_id: string}>}
+ */
+function findStaleMatches(existingMatches, computedMatchKeys) {
+  return existingMatches.filter(m => {
+    const key = `${m.client_id}:${m.opportunity_id}`;
+    return !computedMatchKeys.has(key);
+  });
+}
+
+/**
+ * Build UPSERT row for a match.
+ * is_new and first_matched_at are intentionally excluded from the payload:
+ * - New rows get DB defaults: is_new=true, first_matched_at=NOW()
+ * - Existing rows preserve their values via ON CONFLICT (columns not in payload are untouched)
+ * This approach also avoids race conditions between concurrent triggers.
+ *
+ * @param {Object} match - { client_id, opportunity_id, score, match_details }
+ * @returns {Object} UPSERT row (same shape for new and existing matches)
+ */
+function buildUpsertRow(match) {
+  const now = new Date().toISOString();
+  return {
+    client_id: match.client_id,
+    opportunity_id: match.opportunity_id,
+    score: match.score,
+    match_details: match.match_details,
+    last_matched_at: now,
+    is_stale: false,
+    stale_at: null
+  };
+}
+
+/**
+ * Build stale update for a match that no longer qualifies.
+ *
+ * @param {Object} match - { client_id, opportunity_id }
+ * @param {boolean} alreadyStale - Whether the match is already marked stale
+ * @returns {Object|null} Update payload or null if already stale
+ */
+function buildStaleUpdate(match, alreadyStale) {
+  if (alreadyStale) return null; // Don't re-stale
+  return {
+    is_stale: true,
+    stale_at: new Date().toISOString()
+  };
+}
+
+/**
+ * Compute delta stats from classification results.
+ *
+ * @param {Array<{client_id: string, opportunity_id: string, score: number}>} computedMatches
+ * @param {Set<string>} existingMatchKeys
+ * @param {Array<{client_id: string, opportunity_id: string}>} staleMatches
+ * @returns {{ new_matches: number, updated_matches: number, stale_matches: number }}
+ */
+function computeDeltaStats(computedMatches, existingMatchKeys, staleMatches) {
+  let newCount = 0;
+  let updatedCount = 0;
+
+  for (const match of computedMatches) {
+    const key = `${match.client_id}:${match.opportunity_id}`;
+    if (existingMatchKeys.has(key)) {
+      updatedCount++;
+    } else {
+      newCount++;
+    }
+  }
+
+  return {
+    new_matches: newCount,
+    updated_matches: updatedCount,
+    stale_matches: staleMatches.length
+  };
+}
+
+// --- Tests ---
+
+describe('Delta Detection: Match Classification', () => {
+  test('match not in existing set is classified as new', () => {
+    const existing = new Set(['clientA:opp1', 'clientA:opp2']);
+    expect(classifyMatch('clientA', 'opp3', existing)).toBe('new');
+  });
+
+  test('match in existing set is classified as updated', () => {
+    const existing = new Set(['clientA:opp1', 'clientA:opp2']);
+    expect(classifyMatch('clientA', 'opp1', existing)).toBe('updated');
+  });
+
+  test('empty existing set means all matches are new', () => {
+    const existing = new Set();
+    expect(classifyMatch('clientA', 'opp1', existing)).toBe('new');
+    expect(classifyMatch('clientB', 'opp2', existing)).toBe('new');
+  });
+});
+
+describe('Delta Detection: Stale Match Detection', () => {
+  test('existing match not in computed set is stale', () => {
+    const existing = [
+      { client_id: 'c1', opportunity_id: 'o1' },
+      { client_id: 'c1', opportunity_id: 'o2' },
+      { client_id: 'c1', opportunity_id: 'o3' }
+    ];
+    const computed = new Set(['c1:o1', 'c1:o3']); // o2 dropped
+    const stale = findStaleMatches(existing, computed);
+    expect(stale).toEqual([{ client_id: 'c1', opportunity_id: 'o2' }]);
+  });
+
+  test('no stale matches when all existing are still computed', () => {
+    const existing = [
+      { client_id: 'c1', opportunity_id: 'o1' },
+      { client_id: 'c1', opportunity_id: 'o2' }
+    ];
+    const computed = new Set(['c1:o1', 'c1:o2']);
+    const stale = findStaleMatches(existing, computed);
+    expect(stale).toEqual([]);
+  });
+
+  test('all existing matches become stale when nothing computes', () => {
+    const existing = [
+      { client_id: 'c1', opportunity_id: 'o1' },
+      { client_id: 'c1', opportunity_id: 'o2' }
+    ];
+    const computed = new Set();
+    const stale = findStaleMatches(existing, computed);
+    expect(stale).toHaveLength(2);
+  });
+
+  test('empty existing set produces no stale matches', () => {
+    const stale = findStaleMatches([], new Set(['c1:o1']));
+    expect(stale).toEqual([]);
+  });
+});
+
+describe('Delta Detection: UPSERT Row Building', () => {
+  test('upsert row excludes is_new and first_matched_at (DB defaults handle them)', () => {
+    const row = buildUpsertRow(
+      { client_id: 'c1', opportunity_id: 'o1', score: 75, match_details: { locationMatch: true } }
+    );
+    // is_new and first_matched_at are NOT in the payload — DB handles them
+    expect(row.is_new).toBeUndefined();
+    expect(row.first_matched_at).toBeUndefined();
+    expect(row.last_matched_at).toBeDefined();
+    expect(row.score).toBe(75);
+    expect(row.is_stale).toBe(false);
+    expect(row.stale_at).toBeNull();
+  });
+
+  test('upsert row shape is identical for new and existing matches', () => {
+    const match = { client_id: 'c1', opportunity_id: 'o1', score: 80, match_details: {} };
+    const row = buildUpsertRow(match);
+    // Same payload regardless — ON CONFLICT handles the difference
+    expect(Object.keys(row).sort()).toEqual([
+      'client_id', 'is_stale', 'last_matched_at', 'match_details',
+      'opportunity_id', 'score', 'stale_at'
+    ]);
+  });
+});
+
+describe('Delta Detection: Stale Update Building', () => {
+  test('non-stale match gets stale update', () => {
+    const update = buildStaleUpdate({ client_id: 'c1', opportunity_id: 'o1' }, false);
+    expect(update).not.toBeNull();
+    expect(update.is_stale).toBe(true);
+    expect(update.stale_at).toBeDefined();
+  });
+
+  test('already-stale match returns null (no-op)', () => {
+    const update = buildStaleUpdate({ client_id: 'c1', opportunity_id: 'o1' }, true);
+    expect(update).toBeNull();
+  });
+});
+
+describe('Delta Detection: Stats Computation', () => {
+  test('correct counts for mixed new, updated, and stale', () => {
+    const computed = [
+      { client_id: 'c1', opportunity_id: 'o1', score: 80 }, // existing → updated
+      { client_id: 'c1', opportunity_id: 'o2', score: 60 }, // existing → updated
+      { client_id: 'c1', opportunity_id: 'o4', score: 90 }  // new
+    ];
+    const existing = new Set(['c1:o1', 'c1:o2', 'c1:o3']);
+    const stale = [{ client_id: 'c1', opportunity_id: 'o3' }]; // o3 dropped
+
+    const stats = computeDeltaStats(computed, existing, stale);
+    expect(stats.new_matches).toBe(1);
+    expect(stats.updated_matches).toBe(2);
+    expect(stats.stale_matches).toBe(1);
+  });
+
+  test('all new when no existing matches', () => {
+    const computed = [
+      { client_id: 'c1', opportunity_id: 'o1', score: 80 },
+      { client_id: 'c1', opportunity_id: 'o2', score: 60 }
+    ];
+    const stats = computeDeltaStats(computed, new Set(), []);
+    expect(stats.new_matches).toBe(2);
+    expect(stats.updated_matches).toBe(0);
+    expect(stats.stale_matches).toBe(0);
+  });
+
+  test('zero matches when nothing computes', () => {
+    const stats = computeDeltaStats([], new Set(['c1:o1']), [{ client_id: 'c1', opportunity_id: 'o1' }]);
+    expect(stats.new_matches).toBe(0);
+    expect(stats.updated_matches).toBe(0);
+    expect(stats.stale_matches).toBe(1);
+  });
+});
+
+describe('Delta Detection: Edge Cases', () => {
+  test('client with empty project_needs produces score 0 (match still valid)', () => {
+    // evaluateMatch returns score=0 when client has no project_needs
+    // The delta detection should still classify it correctly
+    const computed = [{ client_id: 'c1', opportunity_id: 'o1', score: 0 }];
+    const stats = computeDeltaStats(computed, new Set(), []);
+    expect(stats.new_matches).toBe(1);
+  });
+
+  test('multiple clients and opportunities produce correct keys', () => {
+    const existing = new Set(['c1:o1', 'c2:o1', 'c1:o2']);
+    expect(classifyMatch('c1', 'o1', existing)).toBe('updated');
+    expect(classifyMatch('c2', 'o1', existing)).toBe('updated');
+    expect(classifyMatch('c1', 'o2', existing)).toBe('updated');
+    expect(classifyMatch('c2', 'o2', existing)).toBe('new');
+    expect(classifyMatch('c3', 'o1', existing)).toBe('new');
+  });
+
+  test('previously stale match that reappears gets un-staled', () => {
+    // When a match was stale but now computes again, the UPSERT row
+    // should set is_stale=false and stale_at=null
+    const row = buildUpsertRow(
+      { client_id: 'c1', opportunity_id: 'o1', score: 70, match_details: {} }
+    );
+    expect(row.is_stale).toBe(false);
+    expect(row.stale_at).toBeNull();
+  });
+});

--- a/tests/critical/client-matching/matchEvaluation.test.js
+++ b/tests/critical/client-matching/matchEvaluation.test.js
@@ -1,11 +1,10 @@
 /**
  * Client Match Evaluation Critical Tests
  *
- * Tests the full 4-criteria match evaluation logic used by:
- * - /api/client-matching/summary (countMatches / evaluateMatch)
- * - /api/client-matching/top-matches (calculateMatches / evaluateMatch with scoring)
+ * Tests the full 4-criteria match evaluation logic used by all client-matching routes
+ * via the shared module: lib/matching/evaluateMatch.js
  *
- * Both routes share the same match criteria; top-matches adds scoring.
+ * All routes now use identical logic with normalizeType for plural tolerance.
  */
 
 import { describe, test, expect } from 'vitest';
@@ -82,8 +81,23 @@ function getExpandedClientTypes(clientType) {
 }
 
 /**
- * Full 4-criteria evaluateMatch (boolean version, used by summary route).
- * Mirrors: app/api/client-matching/summary/route.js lines 163-234
+ * Normalize a type string for matching comparison.
+ * Mirrors: lib/matching/evaluateMatch.js normalizeType()
+ */
+function normalizeType(type) {
+	if (!type) return '';
+	return type
+		.toLowerCase()
+		.trim()
+		.replace(/ies$/, 'y')
+		.replace(/(ch|sh|ss|x|z)es$/, '$1')
+		.replace(/s$/, '');
+}
+
+/**
+ * Full 4-criteria evaluateMatch (boolean version).
+ * Mirrors: lib/matching/evaluateMatch.js (shared module)
+ * Now includes normalizeType for applicant type matching (consistent across all routes).
  */
 function evaluateMatch(client, opportunity) {
 	// 1. Location Match
@@ -102,18 +116,21 @@ function evaluateMatch(client, opportunity) {
 	}
 	if (!locationMatch) return false;
 
-	// 2. Applicant Type Match
+	// 2. Applicant Type Match (with normalizeType)
 	let applicantTypeMatch = false;
 	if (opportunity.eligible_applicants && Array.isArray(opportunity.eligible_applicants)) {
 		const expandedTypes = getExpandedClientTypes(client.type);
-		applicantTypeMatch = opportunity.eligible_applicants.some(applicant =>
-			expandedTypes.some(
-				clientType =>
-					applicant.toLowerCase() === clientType.toLowerCase() ||
-					applicant.toLowerCase().includes(clientType.toLowerCase()) ||
-					clientType.toLowerCase().includes(applicant.toLowerCase())
-			)
-		);
+		applicantTypeMatch = opportunity.eligible_applicants.some(applicant => {
+			const normalizedApplicant = normalizeType(applicant);
+			return expandedTypes.some(clientType => {
+				const normalizedClient = normalizeType(clientType);
+				return (
+					normalizedApplicant === normalizedClient ||
+					normalizedApplicant.includes(normalizedClient) ||
+					normalizedClient.includes(normalizedApplicant)
+				);
+			});
+		});
 	}
 	if (!applicantTypeMatch) return false;
 
@@ -155,8 +172,9 @@ function evaluateMatch(client, opportunity) {
 }
 
 /**
- * evaluateMatch with scoring (used by top-matches route).
- * Mirrors: app/api/client-matching/top-matches/route.js lines 177-267
+ * evaluateMatch with scoring.
+ * Mirrors: lib/matching/evaluateMatch.js (shared module)
+ * Now includes normalizeType for applicant type matching.
  */
 function evaluateMatchWithScore(client, opportunity) {
 	const details = {
@@ -179,17 +197,20 @@ function evaluateMatchWithScore(client, opportunity) {
 		);
 	}
 
-	// 2. Applicant Type
+	// 2. Applicant Type (with normalizeType)
 	if (opportunity.eligible_applicants && Array.isArray(opportunity.eligible_applicants)) {
 		const expandedTypes = getExpandedClientTypes(client.type);
-		details.applicantTypeMatch = opportunity.eligible_applicants.some(applicant =>
-			expandedTypes.some(
-				ct =>
-					applicant.toLowerCase() === ct.toLowerCase() ||
-					applicant.toLowerCase().includes(ct.toLowerCase()) ||
-					ct.toLowerCase().includes(applicant.toLowerCase())
-			)
-		);
+		details.applicantTypeMatch = opportunity.eligible_applicants.some(applicant => {
+			const normalizedApplicant = normalizeType(applicant);
+			return expandedTypes.some(ct => {
+				const normalizedCt = normalizeType(ct);
+				return (
+					normalizedApplicant === normalizedCt ||
+					normalizedApplicant.includes(normalizedCt) ||
+					normalizedCt.includes(normalizedApplicant)
+				);
+			});
+		});
 	}
 
 	// 3. Project Needs
@@ -461,5 +482,50 @@ describe('Client Match Evaluation with Scoring (Top-Matches Route Logic)', () =>
 			expect(top5).toHaveLength(5);
 			expect(top5[0].match_count).toBe(10);
 		});
+	});
+});
+
+describe('normalizeType', () => {
+	test('strips -ies plural to -y', () => {
+		expect(normalizeType('agencies')).toBe('agency');
+		expect(normalizeType('utilities')).toBe('utility');
+		expect(normalizeType('counties')).toBe('county');
+	});
+
+	test('strips -es after ch/sh/ss/x/z', () => {
+		expect(normalizeType('churches')).toBe('church');
+		// "businesses" → "business" (ss rule) → "busines" (trailing s rule)
+		// Both "businesses" and "business" normalize to "busines", enabling matching
+		expect(normalizeType('businesses')).toBe('busines');
+		expect(normalizeType('business')).toBe('busines');
+	});
+
+	test('strips trailing -s', () => {
+		expect(normalizeType('hospitals')).toBe('hospital');
+		expect(normalizeType('governments')).toBe('government');
+		expect(normalizeType('colleges')).toBe('college');
+	});
+
+	test('lowercases and trims', () => {
+		expect(normalizeType('  Municipal Government  ')).toBe('municipal government');
+		expect(normalizeType('LOCAL GOVERNMENTS')).toBe('local government');
+	});
+
+	test('handles null/empty', () => {
+		expect(normalizeType(null)).toBe('');
+		expect(normalizeType(undefined)).toBe('');
+		expect(normalizeType('')).toBe('');
+	});
+
+	test('singular types pass through unchanged', () => {
+		expect(normalizeType('school')).toBe('school');
+		expect(normalizeType('municipality')).toBe('municipality');
+	});
+
+	test('normalizeType enables plural-tolerant applicant matching', () => {
+		// "Local Governments" (opportunity) should match "Local Government" (client type)
+		const applicant = 'Local Governments';
+		const clientType = 'Local Government';
+		expect(normalizeType(applicant)).toBe(normalizeType(clientType));
 	});
 });

--- a/tests/database/constraints/matchJobLogs.test.js
+++ b/tests/database/constraints/matchJobLogs.test.js
@@ -1,0 +1,277 @@
+/**
+ * Database Constraints: Match Job Logs & Client Matches Stale Columns Tests
+ *
+ * Tests the expected schema behavior for:
+ * - match_job_logs table structure and defaults
+ * - client_matches stale tracking columns (is_stale, stale_at)
+ * - Column defaults and constraints
+ *
+ * NOTE: These tests validate expected behavior patterns using inline functions.
+ * For full integration tests, run against real Supabase.
+ */
+
+import { describe, test, expect } from 'vitest';
+
+// --- Inline functions mirroring schema defaults and constraints ---
+
+/**
+ * Simulate inserting a row into match_job_logs with DB defaults.
+ * Mirrors the DEFAULT values from the migration.
+ */
+function createJobLogRow(input) {
+  return {
+    id: input.id || crypto.randomUUID(),
+    trigger: input.trigger,  // NOT NULL, no default — must be provided
+    started_at: input.started_at || new Date().toISOString(),  // DEFAULT NOW()
+    completed_at: input.completed_at || null,  // nullable
+    status: input.status || 'running',  // DEFAULT 'running'
+    stats: input.stats || {},  // DEFAULT '{}'::jsonb
+    error: input.error || null,  // nullable
+    scope: input.scope || {}  // DEFAULT '{}'::jsonb
+  };
+}
+
+/**
+ * Validate match_job_logs row has required fields.
+ */
+function validateJobLogRow(row) {
+  const errors = [];
+  if (!row.id) errors.push('Missing id');
+  if (!row.trigger) errors.push('Missing trigger (NOT NULL)');
+  if (!row.started_at) errors.push('Missing started_at (NOT NULL)');
+  if (!row.status) errors.push('Missing status (NOT NULL)');
+  const validStatuses = ['running', 'completed', 'failed'];
+  if (!validStatuses.includes(row.status)) {
+    errors.push(`Invalid status: ${row.status}. Must be one of: ${validStatuses.join(', ')}`);
+  }
+  const validTriggers = ['cron', 'opportunity_stored', 'client_created', 'client_updated',
+    'manual', 'manual_full', 'manual_client', 'manual_opportunities'];
+  if (!validTriggers.includes(row.trigger)) {
+    errors.push(`Invalid trigger: ${row.trigger}. Must be one of: ${validTriggers.join(', ')}`);
+  }
+  return errors;
+}
+
+/**
+ * Simulate client_matches row with stale columns.
+ * Mirrors the schema after the migration adds is_stale and stale_at.
+ */
+function createClientMatchRow(input) {
+  return {
+    id: input.id || crypto.randomUUID(),
+    client_id: input.client_id,
+    opportunity_id: input.opportunity_id,
+    score: input.score ?? 0,  // DEFAULT 0
+    match_details: input.match_details || {},  // DEFAULT '{}'::jsonb
+    first_matched_at: input.first_matched_at || new Date().toISOString(),  // DEFAULT NOW()
+    last_matched_at: input.last_matched_at || new Date().toISOString(),  // DEFAULT NOW()
+    is_new: input.is_new ?? true,  // DEFAULT true
+    is_stale: input.is_stale ?? false,  // DEFAULT false (from migration)
+    stale_at: input.stale_at || null  // nullable (from migration)
+  };
+}
+
+/**
+ * Check UNIQUE constraint on client_matches(client_id, opportunity_id).
+ */
+function wouldViolateUnique(newRow, existingRows) {
+  return existingRows.some(existing =>
+    existing.client_id === newRow.client_id &&
+    existing.opportunity_id === newRow.opportunity_id
+  );
+}
+
+/**
+ * Simulate RLS policy check.
+ * authenticated: SELECT only
+ * service_role: ALL operations
+ */
+function checkRlsPolicy(role, operation) {
+  if (role === 'service_role') return true;
+  if (role === 'authenticated' && operation === 'SELECT') return true;
+  return false;
+}
+
+// --- Tests ---
+
+describe('Match Job Logs: Defaults', () => {
+  test('minimal insert gets correct defaults', () => {
+    const row = createJobLogRow({ trigger: 'cron' });
+    expect(row.status).toBe('running');
+    expect(row.started_at).toBeDefined();
+    expect(row.completed_at).toBeNull();
+    expect(row.stats).toEqual({});
+    expect(row.error).toBeNull();
+    expect(row.scope).toEqual({});
+  });
+
+  test('trigger is required (NOT NULL)', () => {
+    const row = createJobLogRow({ trigger: undefined });
+    const errors = validateJobLogRow(row);
+    expect(errors).toContain('Missing trigger (NOT NULL)');
+  });
+
+  test('all valid triggers are accepted', () => {
+    const triggers = ['cron', 'opportunity_stored', 'client_created', 'client_updated',
+      'manual', 'manual_full', 'manual_client', 'manual_opportunities'];
+    for (const trigger of triggers) {
+      const row = createJobLogRow({ trigger });
+      const errors = validateJobLogRow(row);
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  test('invalid status is rejected', () => {
+    const row = createJobLogRow({ trigger: 'cron', status: 'pending' });
+    const errors = validateJobLogRow(row);
+    expect(errors.some(e => e.includes('Invalid status'))).toBe(true);
+  });
+});
+
+describe('Match Job Logs: Lifecycle', () => {
+  test('running job has no completed_at or error', () => {
+    const row = createJobLogRow({ trigger: 'cron', status: 'running' });
+    expect(row.completed_at).toBeNull();
+    expect(row.error).toBeNull();
+  });
+
+  test('completed job has completed_at and stats', () => {
+    const row = createJobLogRow({
+      trigger: 'cron',
+      status: 'completed',
+      completed_at: new Date().toISOString(),
+      stats: { new_matches: 10, duration_ms: 500 }
+    });
+    expect(row.completed_at).toBeDefined();
+    expect(row.stats.new_matches).toBe(10);
+    expect(row.error).toBeNull();
+  });
+
+  test('failed job has error message', () => {
+    const row = createJobLogRow({
+      trigger: 'opportunity_stored',
+      status: 'failed',
+      completed_at: new Date().toISOString(),
+      error: 'Connection timeout'
+    });
+    expect(row.error).toBe('Connection timeout');
+    expect(row.completed_at).toBeDefined();
+  });
+});
+
+describe('Client Matches: Stale Columns', () => {
+  test('new match defaults to is_stale=false', () => {
+    const row = createClientMatchRow({
+      client_id: 'c1',
+      opportunity_id: 'o1',
+      score: 80
+    });
+    expect(row.is_stale).toBe(false);
+    expect(row.stale_at).toBeNull();
+  });
+
+  test('stale match has is_stale=true and stale_at set', () => {
+    const row = createClientMatchRow({
+      client_id: 'c1',
+      opportunity_id: 'o1',
+      is_stale: true,
+      stale_at: new Date().toISOString()
+    });
+    expect(row.is_stale).toBe(true);
+    expect(row.stale_at).toBeDefined();
+  });
+
+  test('un-staling resets is_stale and stale_at', () => {
+    // Simulate a match that was stale but is now active again
+    const staleRow = createClientMatchRow({
+      client_id: 'c1',
+      opportunity_id: 'o1',
+      is_stale: true,
+      stale_at: '2026-01-01T00:00:00.000Z'
+    });
+    expect(staleRow.is_stale).toBe(true);
+
+    // Un-stale it
+    const activeRow = createClientMatchRow({
+      ...staleRow,
+      is_stale: false,
+      stale_at: null
+    });
+    expect(activeRow.is_stale).toBe(false);
+    expect(activeRow.stale_at).toBeNull();
+  });
+
+  test('is_new defaults to true for new matches', () => {
+    const row = createClientMatchRow({
+      client_id: 'c1',
+      opportunity_id: 'o1'
+    });
+    expect(row.is_new).toBe(true);
+  });
+
+  test('first_matched_at defaults to current time', () => {
+    const before = new Date().toISOString();
+    const row = createClientMatchRow({
+      client_id: 'c1',
+      opportunity_id: 'o1'
+    });
+    expect(row.first_matched_at).toBeDefined();
+    expect(row.first_matched_at >= before).toBe(true);
+  });
+});
+
+describe('Client Matches: Unique Constraint', () => {
+  test('duplicate client_id + opportunity_id violates unique', () => {
+    const existing = [
+      { client_id: 'c1', opportunity_id: 'o1' },
+      { client_id: 'c1', opportunity_id: 'o2' }
+    ];
+    const newRow = { client_id: 'c1', opportunity_id: 'o1' };
+    expect(wouldViolateUnique(newRow, existing)).toBe(true);
+  });
+
+  test('different opportunity_id does not violate unique', () => {
+    const existing = [
+      { client_id: 'c1', opportunity_id: 'o1' }
+    ];
+    const newRow = { client_id: 'c1', opportunity_id: 'o3' };
+    expect(wouldViolateUnique(newRow, existing)).toBe(false);
+  });
+
+  test('same opportunity_id but different client_id does not violate unique', () => {
+    const existing = [
+      { client_id: 'c1', opportunity_id: 'o1' }
+    ];
+    const newRow = { client_id: 'c2', opportunity_id: 'o1' };
+    expect(wouldViolateUnique(newRow, existing)).toBe(false);
+  });
+});
+
+describe('Match Job Logs: RLS Policies', () => {
+  test('authenticated users can SELECT', () => {
+    expect(checkRlsPolicy('authenticated', 'SELECT')).toBe(true);
+  });
+
+  test('authenticated users cannot INSERT', () => {
+    expect(checkRlsPolicy('authenticated', 'INSERT')).toBe(false);
+  });
+
+  test('authenticated users cannot UPDATE', () => {
+    expect(checkRlsPolicy('authenticated', 'UPDATE')).toBe(false);
+  });
+
+  test('authenticated users cannot DELETE', () => {
+    expect(checkRlsPolicy('authenticated', 'DELETE')).toBe(false);
+  });
+
+  test('service_role can do all operations', () => {
+    expect(checkRlsPolicy('service_role', 'SELECT')).toBe(true);
+    expect(checkRlsPolicy('service_role', 'INSERT')).toBe(true);
+    expect(checkRlsPolicy('service_role', 'UPDATE')).toBe(true);
+    expect(checkRlsPolicy('service_role', 'DELETE')).toBe(true);
+  });
+
+  test('anonymous users cannot access', () => {
+    expect(checkRlsPolicy('anon', 'SELECT')).toBe(false);
+  });
+});

--- a/tests/database/integration/schema.integration.test.js
+++ b/tests/database/integration/schema.integration.test.js
@@ -444,6 +444,60 @@ describe('Table: clients', () => {
 });
 
 // ---------------------------------------------------------------------------
+// client_matches table
+// ---------------------------------------------------------------------------
+describe('Table: client_matches', () => {
+  test('has all expected columns', async (ctx) => {
+    const reason = db.requireSupabase();
+    if (reason) return ctx.skip(reason);
+
+    const result = await getColumnNames('client_matches');
+    expect(result.error).toBeNull();
+    expect(result.empty).toBeFalsy();
+
+    const EXPECTED_COLUMNS = [
+      'id', 'client_id', 'opportunity_id', 'score',
+      'match_details', 'first_matched_at', 'last_matched_at', 'is_new',
+    ];
+
+    const missing = EXPECTED_COLUMNS.filter(col => !result.columns.has(col));
+    expect(missing).toEqual([]);
+  });
+
+  test('unique constraint on client_id + opportunity_id', async (ctx) => {
+    const reason = db.requireSupabase();
+    if (reason) return ctx.skip(reason);
+
+    // Insert requires valid FK references — just verify the table is queryable
+    // and the constraint exists by checking error on duplicate insert
+    const { error } = await db.supabase
+      .from('client_matches')
+      .select('id')
+      .limit(1);
+
+    expect(error).toBeNull();
+  });
+
+  test('client_id references clients (FK)', async (ctx) => {
+    const reason = db.requireSupabase();
+    if (reason) return ctx.skip(reason);
+
+    const fakeUuid = '00000000-0000-0000-0000-000000000000';
+    const { error } = await db.supabase
+      .from('client_matches')
+      .insert({
+        client_id: fakeUuid,
+        opportunity_id: fakeUuid,
+        score: 50,
+      })
+      .select();
+
+    // Should fail due to FK constraint on client_id or opportunity_id
+    expect(error).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Foreign key relationships
 // ---------------------------------------------------------------------------
 describe('Foreign Key Relationships', () => {

--- a/tests/pipeline/matchComputation.test.js
+++ b/tests/pipeline/matchComputation.test.js
@@ -1,0 +1,236 @@
+/**
+ * Match Computation Job Tests
+ *
+ * Tests the background match computation job execution flow.
+ * Uses inline functions mirroring lib/matching/computeMatches.js.
+ */
+
+import { describe, test, expect } from 'vitest';
+
+// --- Inline functions mirroring computeMatches.js job logic ---
+
+/**
+ * Build the stats object returned by a match computation job.
+ * Mirrors the stats shape from runMatchComputation().
+ */
+function buildJobStats({
+  clientCount,
+  opportunityCount,
+  newMatches,
+  updatedMatches,
+  staleMatches,
+  totalActiveMatches,
+  durationMs
+}) {
+  return {
+    clients_processed: clientCount,
+    opportunities_evaluated: opportunityCount,
+    pairs_evaluated: clientCount * opportunityCount,
+    new_matches: newMatches,
+    updated_matches: updatedMatches,
+    stale_matches: staleMatches,
+    total_active_matches: totalActiveMatches,
+    duration_ms: durationMs
+  };
+}
+
+/**
+ * Determine the trigger type for a match computation.
+ */
+function determineTrigger(scope) {
+  if (!scope || Object.keys(scope).length === 0) return 'cron';
+  if (scope.clientIds?.length) return 'client_updated';
+  if (scope.opportunityIds?.length) return 'opportunity_stored';
+  return 'cron';
+}
+
+/**
+ * Validate that a scope correctly limits computation.
+ * Returns which dimension is scoped (or 'full' for no scope).
+ */
+function getScopeType(scope) {
+  if (!scope || Object.keys(scope).length === 0) return 'full';
+  if (scope.clientIds?.length && scope.opportunityIds?.length) return 'both';
+  if (scope.clientIds?.length) return 'client';
+  if (scope.opportunityIds?.length) return 'opportunity';
+  return 'full';
+}
+
+/**
+ * Build a match job log record.
+ */
+function buildJobLog({ trigger, scope, status, stats, error }) {
+  return {
+    trigger,
+    scope: scope || {},
+    started_at: new Date().toISOString(),
+    completed_at: status !== 'running' ? new Date().toISOString() : null,
+    status,
+    stats: stats || {},
+    error: error || null
+  };
+}
+
+// --- Tests ---
+
+describe('Match Computation: Stats Shape', () => {
+  test('full computation stats have correct shape', () => {
+    const stats = buildJobStats({
+      clientCount: 50,
+      opportunityCount: 500,
+      newMatches: 120,
+      updatedMatches: 30,
+      staleMatches: 5,
+      totalActiveMatches: 150,
+      durationMs: 850
+    });
+
+    expect(stats.clients_processed).toBe(50);
+    expect(stats.opportunities_evaluated).toBe(500);
+    expect(stats.pairs_evaluated).toBe(25000);
+    expect(stats.new_matches).toBe(120);
+    expect(stats.updated_matches).toBe(30);
+    expect(stats.stale_matches).toBe(5);
+    expect(stats.total_active_matches).toBe(150);
+    expect(stats.duration_ms).toBe(850);
+  });
+
+  test('zero clients produces zero pairs', () => {
+    const stats = buildJobStats({
+      clientCount: 0,
+      opportunityCount: 500,
+      newMatches: 0,
+      updatedMatches: 0,
+      staleMatches: 0,
+      totalActiveMatches: 0,
+      durationMs: 10
+    });
+
+    expect(stats.pairs_evaluated).toBe(0);
+    expect(stats.total_active_matches).toBe(0);
+  });
+});
+
+describe('Match Computation: Trigger Detection', () => {
+  test('empty scope is cron trigger', () => {
+    expect(determineTrigger({})).toBe('cron');
+    expect(determineTrigger(null)).toBe('cron');
+    expect(determineTrigger(undefined)).toBe('cron');
+  });
+
+  test('clientIds scope is client_updated trigger', () => {
+    expect(determineTrigger({ clientIds: ['abc-123'] })).toBe('client_updated');
+  });
+
+  test('opportunityIds scope is opportunity_stored trigger', () => {
+    expect(determineTrigger({ opportunityIds: ['opp-1', 'opp-2'] })).toBe('opportunity_stored');
+  });
+});
+
+describe('Match Computation: Scope Types', () => {
+  test('no scope is full computation', () => {
+    expect(getScopeType({})).toBe('full');
+    expect(getScopeType(null)).toBe('full');
+  });
+
+  test('clientIds scope is client-scoped', () => {
+    expect(getScopeType({ clientIds: ['c1'] })).toBe('client');
+  });
+
+  test('opportunityIds scope is opportunity-scoped', () => {
+    expect(getScopeType({ opportunityIds: ['o1', 'o2'] })).toBe('opportunity');
+  });
+
+  test('both scopes is both-scoped', () => {
+    expect(getScopeType({ clientIds: ['c1'], opportunityIds: ['o1'] })).toBe('both');
+  });
+});
+
+describe('Match Computation: Job Logging', () => {
+  test('running job log has no completed_at', () => {
+    const log = buildJobLog({
+      trigger: 'cron',
+      scope: {},
+      status: 'running'
+    });
+
+    expect(log.trigger).toBe('cron');
+    expect(log.status).toBe('running');
+    expect(log.started_at).toBeDefined();
+    expect(log.completed_at).toBeNull();
+    expect(log.error).toBeNull();
+  });
+
+  test('completed job log has stats and completed_at', () => {
+    const stats = buildJobStats({
+      clientCount: 10,
+      opportunityCount: 100,
+      newMatches: 25,
+      updatedMatches: 5,
+      staleMatches: 2,
+      totalActiveMatches: 30,
+      durationMs: 450
+    });
+
+    const log = buildJobLog({
+      trigger: 'client_updated',
+      scope: { clientIds: ['c1'] },
+      status: 'completed',
+      stats
+    });
+
+    expect(log.status).toBe('completed');
+    expect(log.completed_at).toBeDefined();
+    expect(log.stats.new_matches).toBe(25);
+    expect(log.scope.clientIds).toEqual(['c1']);
+  });
+
+  test('failed job log has error message', () => {
+    const log = buildJobLog({
+      trigger: 'opportunity_stored',
+      scope: { opportunityIds: ['o1'] },
+      status: 'failed',
+      error: 'Failed to fetch opportunities: connection timeout'
+    });
+
+    expect(log.status).toBe('failed');
+    expect(log.error).toContain('connection timeout');
+    expect(log.completed_at).toBeDefined();
+  });
+});
+
+describe('Match Computation: Scoped vs Full', () => {
+  test('client-scoped computation only processes that client', () => {
+    // Simulate: 1 client, all opportunities
+    const stats = buildJobStats({
+      clientCount: 1,
+      opportunityCount: 500,
+      newMatches: 8,
+      updatedMatches: 2,
+      staleMatches: 1,
+      totalActiveMatches: 10,
+      durationMs: 50
+    });
+
+    expect(stats.clients_processed).toBe(1);
+    expect(stats.opportunities_evaluated).toBe(500);
+    expect(stats.pairs_evaluated).toBe(500); // 1 client x 500 opps
+  });
+
+  test('opportunity-scoped computation evaluates all clients against specific opps', () => {
+    // Simulate: all clients, 3 new opportunities
+    const stats = buildJobStats({
+      clientCount: 50,
+      opportunityCount: 3,
+      newMatches: 15,
+      updatedMatches: 0,
+      staleMatches: 0,
+      totalActiveMatches: 15,
+      durationMs: 30
+    });
+
+    expect(stats.clients_processed).toBe(50);
+    expect(stats.opportunities_evaluated).toBe(3);
+    expect(stats.pairs_evaluated).toBe(150); // 50 clients x 3 opps
+  });
+});

--- a/tests/pipeline/matchComputation.test.js
+++ b/tests/pipeline/matchComputation.test.js
@@ -199,6 +199,70 @@ describe('Match Computation: Job Logging', () => {
   });
 });
 
+describe('Match Computation: First-Time Client Detection', () => {
+  /**
+   * Identify clients with zero prior matches (first-ever computation).
+   * Mirrors lib/matching/computeMatches.js lines 160-167.
+   */
+  function identifyFirstTimeClients(clients, existingMatches) {
+    const clientsWithExistingMatches = new Set(
+      (existingMatches || []).map(m => m.client_id)
+    );
+    return clients
+      .map(c => c.id)
+      .filter(cid => !clientsWithExistingMatches.has(cid));
+  }
+
+  test('brand new clients with no existing matches are identified', () => {
+    const clients = [
+      { id: 'c1' },
+      { id: 'c2' },
+      { id: 'c3' },
+    ];
+    const existingMatches = [
+      { client_id: 'c1', opportunity_id: 'opp-1' },
+    ];
+
+    const firstTime = identifyFirstTimeClients(clients, existingMatches);
+    expect(firstTime).toEqual(['c2', 'c3']);
+  });
+
+  test('all clients are first-time when no existing matches', () => {
+    const clients = [{ id: 'c1' }, { id: 'c2' }];
+    const firstTime = identifyFirstTimeClients(clients, []);
+    expect(firstTime).toEqual(['c1', 'c2']);
+  });
+
+  test('no first-time clients when all have existing matches', () => {
+    const clients = [{ id: 'c1' }, { id: 'c2' }];
+    const existingMatches = [
+      { client_id: 'c1', opportunity_id: 'opp-1' },
+      { client_id: 'c2', opportunity_id: 'opp-2' },
+    ];
+
+    const firstTime = identifyFirstTimeClients(clients, existingMatches);
+    expect(firstTime).toEqual([]);
+  });
+
+  test('handles null existingMatches gracefully', () => {
+    const clients = [{ id: 'c1' }];
+    const firstTime = identifyFirstTimeClients(clients, null);
+    expect(firstTime).toEqual(['c1']);
+  });
+
+  test('a client with any match is not first-time (even one)', () => {
+    const clients = [{ id: 'c1' }, { id: 'c2' }];
+    const existingMatches = [
+      { client_id: 'c1', opportunity_id: 'opp-1' },
+      { client_id: 'c1', opportunity_id: 'opp-2' },
+      // c2 has no matches — it's first-time
+    ];
+
+    const firstTime = identifyFirstTimeClients(clients, existingMatches);
+    expect(firstTime).toEqual(['c2']);
+  });
+});
+
 describe('Match Computation: Scoped vs Full', () => {
   test('client-scoped computation only processes that client', () => {
     // Simulate: 1 client, all opportunities


### PR DESCRIPTION
## Summary
- Create `client_matches` table and shared matching module — single source of truth for 4-criteria matching (#37)
- Add background match computation job with delta detection, stale tracking, and daily cron (#38)
- Switch all client-matching API routes to read from persisted `client_matches` instead of recomputing (#39)
- Redesign OpportunityCard for visual refinement, brand cohesion, and funding type badges (#57)
- Redesign client match detail page with funding type grouping and improved layout (#58)
- Add worktrees and playwright-mcp to gitignore

Closes #37
Closes #38
Closes #39

## Test plan
- [x] Client matches page loads from persisted `client_matches` table
- [x] Top matches and summary endpoints read from persisted data
- [x] Background match job computes and upserts matches with delta detection
- [x] New matches flagged with `is_new = true` and `first_matched_at`
- [x] Stale matches marked when no longer qualifying
- [x] Hidden matches filtered via batch query (no N+1)
- [x] OpportunityCard redesign renders correctly with funding type badges
- [x] Match detail page groups opportunities by funding type
- [x] All tests pass (`npm run test:critical && npm run test:api`)
- [x] Build passes (`npm run build`)