### PR TITLE
Add user assignment to client form and detail page

### DIFF
--- a/app/api/clients/[id]/route.js
+++ b/app/api/clients/[id]/route.js
@@ -181,6 +181,40 @@ export async function PUT(request, { params }) {
 
     console.log(`[API] ✅ Updated client: ${client.id}`);
 
+    // Sync assigned_users if provided
+    if (Array.isArray(body.assigned_users)) {
+      const { error: deleteError } = await supabase
+        .from('client_users')
+        .delete()
+        .eq('client_id', id);
+
+      if (deleteError) {
+        console.error('[API] Failed to clear client_users:', deleteError.message);
+        return NextResponse.json(
+          { success: false, error: 'Failed to update user assignments' },
+          { status: 500 }
+        );
+      }
+
+      if (body.assigned_users.length > 0) {
+        const rows = body.assigned_users.map((userId) => ({
+          client_id: id,
+          user_id: userId,
+        }));
+        const { error: insertError } = await supabase
+          .from('client_users')
+          .insert(rows);
+        if (insertError) {
+          console.error('[API] Failed to insert client_users:', insertError.message);
+          return NextResponse.json(
+            { success: false, error: 'Failed to save user assignments' },
+            { status: 500 }
+          );
+        }
+        console.log(`[API] Synced ${rows.length} client_users for client ${id}`);
+      }
+    }
+
     // Fire-and-forget: recompute matches for the updated client
     computeMatchesForClient(supabase, client.id).catch(err =>
       console.error('[API] Background match computation failed:', err.message)

--- a/app/api/clients/[id]/users/route.js
+++ b/app/api/clients/[id]/users/route.js
@@ -1,0 +1,36 @@
+/**
+ * Client Users API Route
+ *
+ * GET /api/clients/[id]/users - Get assigned user IDs for a client
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse } from 'next/server';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SECRET_KEY
+);
+
+export async function GET(request, { params }) {
+  try {
+    const { id } = params;
+
+    const { data: rows, error } = await supabase
+      .from('client_users')
+      .select('user_id')
+      .eq('client_id', id);
+
+    if (error) throw error;
+
+    const userIds = (rows || []).map((r) => r.user_id);
+
+    return NextResponse.json({ success: true, user_ids: userIds });
+  } catch (error) {
+    console.error('[API] Error fetching client users:', error);
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/clients/route.js
+++ b/app/api/clients/route.js
@@ -262,14 +262,24 @@ export async function POST(request) {
 
     console.log(`[API] ✅ Created client: ${client.id}`);
 
-    // Create client_users association if authenticated
-    if (ownerId) {
+    // Create client_users associations
+    const assignedUsers = Array.isArray(body.assigned_users) && body.assigned_users.length > 0
+      ? body.assigned_users
+      : (ownerId ? [ownerId] : []);
+
+    if (assignedUsers.length > 0) {
+      const rows = assignedUsers.map((userId) => ({
+        client_id: client.id,
+        user_id: userId,
+      }));
       const { error: assocError } = await supabase
         .from('client_users')
-        .insert({ client_id: client.id, user_id: ownerId });
+        .insert(rows);
 
       if (assocError) {
-        console.error('[API] Failed to create client_users association:', assocError.message);
+        console.error('[API] Failed to create client_users associations:', assocError.message);
+      } else {
+        console.log(`[API] Created ${rows.length} client_users association(s)`);
       }
     }
 

--- a/app/api/users/route.js
+++ b/app/api/users/route.js
@@ -1,0 +1,45 @@
+/**
+ * Users API Route
+ *
+ * GET /api/users - List all workspace users for client assignment
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { NextResponse } from 'next/server';
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SECRET_KEY
+);
+
+/**
+ * GET /api/users
+ * Returns all auth users with id, display_name, email.
+ */
+export async function GET() {
+  try {
+    const { data: { users }, error } = await supabase.auth.admin.listUsers();
+
+    if (error) throw error;
+
+    const mapped = (users || [])
+      .map((u) => ({
+        id: u.id,
+        display_name:
+          u.user_metadata?.full_name ||
+          u.user_metadata?.name ||
+          u.email ||
+          'Unknown User',
+        email: u.email || '',
+      }))
+      .sort((a, b) => a.display_name.localeCompare(b.display_name));
+
+    return NextResponse.json({ success: true, users: mapped });
+  } catch (error) {
+    console.error('[API /users] Error listing users:', error);
+    return NextResponse.json(
+      { success: false, error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/components/clients/ClientForm.jsx
+++ b/components/clients/ClientForm.jsx
@@ -6,7 +6,7 @@
  * Form for creating and editing clients with automatic geocoding and coverage area detection.
  */
 
-import { useState, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -15,6 +15,8 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Combobox } from '@/components/ui/combobox';
 import { AddressAutofillInput } from '@/components/ui/address-autofill-input-client';
 import { TAXONOMIES, getSelectableClientTypes } from '@/lib/constants/taxonomies';
+import { useUsers } from '@/lib/hooks/queries/useUsers';
+import { useAuth } from '@/contexts/AuthContext';
 
 // Get selectable client types (children + standalone + selectable parent exceptions)
 // This encourages users to select specific types rather than broad parent categories
@@ -29,6 +31,14 @@ const PROJECT_NEEDS = [
 
 export default function ClientForm({ client, onSuccess, onCancel }) {
   const isEdit = !!client;
+  const { user } = useAuth();
+  const { data: usersData } = useUsers();
+  const allUsers = useMemo(() => usersData?.users || [], [usersData]);
+
+  const userOptions = useMemo(
+    () => allUsers.map((u) => ({ value: u.id, label: u.display_name })),
+    [allUsers]
+  );
 
   const [formData, setFormData] = useState({
     name: client?.name || '',
@@ -38,13 +48,34 @@ export default function ClientForm({ client, onSuccess, onCancel }) {
     budget: client?.budget || '',
     contact: client?.contact || '',
     description: client?.description || '',
-    dac: client?.dac || false
+    dac: client?.dac || false,
+    assigned_users: [],
   });
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [geocodedInfo, setGeocodedInfo] = useState(null);
   const [autofilledLocation, setAutofilledLocation] = useState(null);
+
+  // Load assigned users: pre-populate current user on add, fetch existing on edit
+  useEffect(() => {
+    let cancelled = false;
+
+    if (isEdit && client?.id) {
+      fetch(`/api/clients/${client.id}/users`)
+        .then((r) => r.json())
+        .then((data) => {
+          if (!cancelled && data.success) {
+            setFormData((prev) => ({ ...prev, assigned_users: data.user_ids || [] }));
+          }
+        })
+        .catch(() => {});
+    } else if (!isEdit && user?.id) {
+      setFormData((prev) => ({ ...prev, assigned_users: [user.id] }));
+    }
+
+    return () => { cancelled = true; };
+  }, [isEdit, client?.id, user?.id]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -300,6 +331,20 @@ export default function ClientForm({ client, onSuccess, onCancel }) {
         <Label htmlFor="dac" className="cursor-pointer">
           Disadvantaged Community (DAC)
         </Label>
+      </div>
+
+      {/* Assigned Users */}
+      <div>
+        <Label>Assigned Users</Label>
+        <Combobox
+          multiple
+          options={userOptions}
+          value={formData.assigned_users}
+          onChange={(value) => setFormData({ ...formData, assigned_users: value })}
+          placeholder="Select users to assign..."
+          searchPlaceholder="Search users..."
+          emptyMessage="No users found."
+        />
       </div>
 
       {/* Buttons */}

--- a/components/clients/ClientProfileModal.jsx
+++ b/components/clients/ClientProfileModal.jsx
@@ -7,7 +7,7 @@
  * Supports editing mode via ClientForm integration.
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -26,20 +26,63 @@ import {
   FileText,
   ExternalLink,
   Pencil,
+  Users,
 } from 'lucide-react';
 import Link from 'next/link';
 import { formatProjectNeeds } from '@/lib/utils/clientMatching';
+import { useUsers } from '@/lib/hooks/queries/useUsers';
 import ClientForm from './ClientForm';
 
 export default function ClientProfileModal({ client, isOpen, onClose, onClientUpdate }) {
   const [isEditing, setIsEditing] = useState(false);
+  const [assignedUserIds, setAssignedUserIds] = useState([]);
 
-  // Reset editing state when modal closes
+  const { data: usersData } = useUsers();
+  const allUsers = useMemo(() => usersData?.users || [], [usersData]);
+
+  // Reset state when modal closes
   useEffect(() => {
-    if (!isOpen) setIsEditing(false);
+    if (!isOpen) {
+      setIsEditing(false);
+      setAssignedUserIds([]);
+    }
   }, [isOpen]);
 
+  // Fetch assigned user IDs when modal opens
+  useEffect(() => {
+    if (!isOpen || !client?.id) return;
+    let cancelled = false;
+
+    fetch(`/api/clients/${client.id}/users`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!cancelled && data.success) {
+          setAssignedUserIds(data.user_ids || []);
+        }
+      })
+      .catch(() => {});
+
+    return () => { cancelled = true; };
+  }, [isOpen, client?.id]);
+
+  // Re-fetch assigned users after an edit saves
+  const handleClientUpdate = (updatedClient) => {
+    setIsEditing(false);
+    // Re-fetch assignments since the edit may have changed them
+    if (updatedClient?.id) {
+      fetch(`/api/clients/${updatedClient.id}/users`)
+        .then((r) => r.json())
+        .then((data) => {
+          if (data.success) setAssignedUserIds(data.user_ids || []);
+        })
+        .catch(() => {});
+    }
+    onClientUpdate?.(updatedClient);
+  };
+
   if (!client) return null;
+
+  const assignedUsers = allUsers.filter((u) => assignedUserIds.includes(u.id));
 
   const budgetLabels = {
     small: 'Small ($50K - $500K)',
@@ -62,10 +105,7 @@ export default function ClientProfileModal({ client, isOpen, onClose, onClientUp
         {isEditing ? (
           <ClientForm
             client={client}
-            onSuccess={(updatedClient) => {
-              setIsEditing(false);
-              onClientUpdate?.(updatedClient);
-            }}
+            onSuccess={handleClientUpdate}
             onCancel={() => setIsEditing(false)}
           />
         ) : (
@@ -155,6 +195,33 @@ export default function ClientProfileModal({ client, isOpen, onClose, onClientUp
               </div>
               {(!client.project_needs || client.project_needs.length === 0) && (
                 <p className="text-neutral-500 italic">No project needs specified</p>
+              )}
+            </div>
+
+            <Separator />
+
+            {/* Assigned Users */}
+            <div>
+              <div className="flex items-center mb-3">
+                <Users className="h-5 w-5 mr-2 text-neutral-500" />
+                <h3 className="text-lg font-semibold">Assigned Users</h3>
+              </div>
+              {assignedUsers.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {assignedUsers.map((u) => (
+                    <div
+                      key={u.id}
+                      className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-neutral-100 dark:bg-neutral-800 text-sm font-medium text-neutral-700 dark:text-neutral-300"
+                    >
+                      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-primary text-xs font-bold">
+                        {u.display_name?.charAt(0)?.toUpperCase() || '?'}
+                      </span>
+                      {u.display_name}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-neutral-500 italic">No users assigned</p>
               )}
             </div>
 

--- a/components/ui/combobox.jsx
+++ b/components/ui/combobox.jsx
@@ -31,6 +31,13 @@ export function Combobox({
   const [open, setOpen] = React.useState(false)
   const [searchValue, setSearchValue] = React.useState("")
 
+  // Normalize options: support both string[] and {value, label}[]
+  const normalizedOptions = React.useMemo(() => {
+    return options.map((opt) =>
+      typeof opt === 'string' ? { value: opt, label: opt } : opt
+    )
+  }, [options])
+
   // Normalize value to always be array internally for easier handling
   const selectedValues = React.useMemo(() => {
     if (multiple) {
@@ -38,6 +45,12 @@ export function Combobox({
     }
     return value ? [value] : []
   }, [value, multiple])
+
+  // Lookup label for a stored value
+  const getLabelForValue = React.useCallback((val) => {
+    const found = normalizedOptions.find((o) => o.value === val)
+    return found ? found.label : val
+  }, [normalizedOptions])
 
   const handleSelect = (currentValue) => {
     if (multiple) {
@@ -66,8 +79,8 @@ export function Combobox({
     if (multiple) {
       return `${selectedValues.length} selected`
     }
-    return selectedValues[0]
-  }, [selectedValues, placeholder, multiple])
+    return getLabelForValue(selectedValues[0])
+  }, [selectedValues, placeholder, multiple, getLabelForValue])
 
   return (
     <div className={cn("w-full", className)}>
@@ -88,7 +101,7 @@ export function Combobox({
                     key={val}
                     className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-primary/10 text-primary text-sm"
                   >
-                    {val}
+                    {getLabelForValue(val)}
                     <div
                       role="button"
                       tabIndex={0}
@@ -103,7 +116,7 @@ export function Combobox({
                           handleRemove(val)
                         }
                       }}
-                      aria-label={`Remove ${val}`}
+                      aria-label={`Remove ${getLabelForValue(val)}`}
                       className="cursor-pointer hover:opacity-70 focus:outline-none focus:ring-1 focus:ring-primary rounded-sm p-0.5 -m-0.5"
                     >
                       <X className="h-3 w-3" />
@@ -127,25 +140,24 @@ export function Combobox({
             <CommandList>
               <CommandEmpty>{emptyMessage}</CommandEmpty>
               <CommandGroup>
-                {options
-                  .filter((option) => {
-                    // Manual filtering since we disabled cmdk's filter
+                {normalizedOptions
+                  .filter((opt) => {
                     if (!searchValue) return true
-                    return option.toLowerCase().includes(searchValue.toLowerCase())
+                    return opt.label.toLowerCase().includes(searchValue.toLowerCase())
                   })
-                  .map((option) => {
-                    const isSelected = selectedValues.includes(option)
+                  .map((opt) => {
+                    const isSelected = selectedValues.includes(opt.value)
                     return (
                       <CommandItem
-                        key={option}
-                        value={option}
+                        key={opt.value}
+                        value={opt.value}
                         onSelect={(selectedValue) => {
                           // cmdk lowercases values, so find the actual option
-                          const actualOption = options.find(
-                            opt => opt.toLowerCase() === selectedValue.toLowerCase()
+                          const actualOpt = normalizedOptions.find(
+                            (o) => o.value.toLowerCase() === selectedValue.toLowerCase()
                           )
-                          if (actualOption) {
-                            handleSelect(actualOption)
+                          if (actualOpt) {
+                            handleSelect(actualOpt.value)
                           }
                         }}
                       >
@@ -155,7 +167,7 @@ export function Combobox({
                             isSelected ? "opacity-100" : "opacity-0"
                           )}
                         />
-                        {option}
+                        {opt.label}
                       </CommandItem>
                     )
                   })}

--- a/lib/hooks/queries/index.js
+++ b/lib/hooks/queries/index.js
@@ -38,3 +38,6 @@ export {
 	useApproveReview,
 	useRejectReview,
 } from './useAdmin';
+
+// Users
+export { useUsers } from './useUsers';

--- a/lib/hooks/queries/useUsers.js
+++ b/lib/hooks/queries/useUsers.js
@@ -1,0 +1,14 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queries/queryKeys';
+import { fetchUsers } from '@/lib/queries/api';
+
+export function useUsers(options = {}) {
+	return useQuery({
+		queryKey: queryKeys.users.list(),
+		queryFn: fetchUsers,
+		staleTime: 5 * 60 * 1000,
+		...options,
+	});
+}

--- a/lib/queries/api.js
+++ b/lib/queries/api.js
@@ -185,6 +185,14 @@ export async function fetchAdminSystemConfig(key) {
 	return get(`/api/admin/system-config/${key}`);
 }
 
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+export async function fetchUsers() {
+	return get('/api/users');
+}
+
 async function post(url, body) {
 	const res = await fetch(url, {
 		method: 'POST',

--- a/lib/queries/queryKeys.js
+++ b/lib/queries/queryKeys.js
@@ -59,4 +59,9 @@ export const queryKeys = {
 		review: (filters) => ['admin', 'review', filters],
 		systemConfig: (key) => ['admin', 'systemConfig', key],
 	},
+
+	users: {
+		all: ['users'],
+		list: () => ['users', 'list'],
+	},
 };

--- a/tests/api/client-users.api.test.js
+++ b/tests/api/client-users.api.test.js
@@ -1,0 +1,100 @@
+/**
+ * Client Users API Contract Tests
+ *
+ * Tests the expected response structure for:
+ * - GET /api/clients/[id]/users - Get assigned user IDs
+ */
+
+import { describe, test, expect } from 'vitest';
+
+/**
+ * Expected response shape for GET /api/clients/[id]/users
+ */
+const clientUsersResponseSchema = {
+  success: 'boolean',
+  user_ids: 'array',
+};
+
+function validateFieldType(value, expectedType) {
+  const types = expectedType.split('|');
+  for (const type of types) {
+    if (type === 'null' && value === null) return true;
+    if (type === 'string' && typeof value === 'string') return true;
+    if (type === 'number' && typeof value === 'number') return true;
+    if (type === 'boolean' && typeof value === 'boolean') return true;
+    if (type === 'array' && Array.isArray(value)) return true;
+  }
+  return false;
+}
+
+function validateSchema(obj, schema) {
+  const errors = [];
+  for (const [key, expectedType] of Object.entries(schema)) {
+    if (!(key in obj)) {
+      errors.push(`Missing field: ${key}`);
+      continue;
+    }
+    if (!validateFieldType(obj[key], expectedType)) {
+      errors.push(`Invalid type for ${key}: expected ${expectedType}, got ${typeof obj[key]}`);
+    }
+  }
+  return errors;
+}
+
+describe('Client Users API Contract', () => {
+
+  describe('GET /api/clients/[id]/users response shape', () => {
+    test('validates success response with user IDs', () => {
+      const response = {
+        success: true,
+        user_ids: ['user-abc-123', 'user-def-456'],
+      };
+
+      const errors = validateSchema(response, clientUsersResponseSchema);
+      expect(errors).toHaveLength(0);
+    });
+
+    test('validates success response with empty user IDs', () => {
+      const response = {
+        success: true,
+        user_ids: [],
+      };
+
+      const errors = validateSchema(response, clientUsersResponseSchema);
+      expect(errors).toHaveLength(0);
+    });
+
+    test('user_ids contains only strings', () => {
+      const userIds = ['user-abc-123', 'user-def-456'];
+
+      for (const id of userIds) {
+        expect(typeof id).toBe('string');
+      }
+    });
+
+    test('missing success field fails validation', () => {
+      const response = { user_ids: [] };
+      const errors = validateSchema(response, clientUsersResponseSchema);
+      expect(errors).toContain('Missing field: success');
+    });
+
+    test('missing user_ids field fails validation', () => {
+      const response = { success: true };
+      const errors = validateSchema(response, clientUsersResponseSchema);
+      expect(errors).toContain('Missing field: user_ids');
+    });
+  });
+
+  describe('Error response shape', () => {
+    test('validates error response', () => {
+      const response = {
+        success: false,
+        error: 'Client not found',
+      };
+
+      expect(response.success).toBe(false);
+      expect(typeof response.error).toBe('string');
+    });
+  });
+
+});

--- a/tests/api/clients.api.test.js
+++ b/tests/api/clients.api.test.js
@@ -148,6 +148,57 @@ describe('Clients API Contract', () => {
     });
   });
 
+  describe('POST /api/clients - assigned_users contract', () => {
+    // Mirrors the resolution logic in POST /api/clients route.js
+    function resolveAssignedUsers(bodyAssignedUsers, ownerId) {
+      if (Array.isArray(bodyAssignedUsers) && bodyAssignedUsers.length > 0) {
+        return bodyAssignedUsers;
+      }
+      return ownerId ? [ownerId] : [];
+    }
+
+    test('accepts assigned_users array in request body', () => {
+      const body = {
+        name: 'Test Client',
+        type: 'Municipal Government',
+        address: '123 Main St',
+        assigned_users: ['user-1', 'user-2'],
+      };
+
+      expect(Array.isArray(body.assigned_users)).toBe(true);
+      expect(resolveAssignedUsers(body.assigned_users, 'owner-1')).toEqual(['user-1', 'user-2']);
+    });
+
+    test('falls back to ownerId when assigned_users absent', () => {
+      const body = {
+        name: 'Test Client',
+        type: 'Municipal Government',
+        address: '123 Main St',
+      };
+
+      expect(resolveAssignedUsers(body.assigned_users, 'owner-1')).toEqual(['owner-1']);
+    });
+  });
+
+  describe('PUT /api/clients/[id] - assigned_users contract', () => {
+    // Mirrors the sync guard in PUT /api/clients/[id] route.js
+    function shouldSyncUsers(body) {
+      return Array.isArray(body.assigned_users);
+    }
+
+    test('syncs when assigned_users is an array', () => {
+      expect(shouldSyncUsers({ assigned_users: ['u1'] })).toBe(true);
+    });
+
+    test('syncs when assigned_users is empty (clears all)', () => {
+      expect(shouldSyncUsers({ assigned_users: [] })).toBe(true);
+    });
+
+    test('skips sync when assigned_users absent (backward compat)', () => {
+      expect(shouldSyncUsers({ name: 'Updated' })).toBe(false);
+    });
+  });
+
   describe('Error Responses', () => {
     test('client not found (404)', () => {
       const response = {

--- a/tests/api/users.api.test.js
+++ b/tests/api/users.api.test.js
@@ -1,0 +1,82 @@
+/**
+ * Users API Contract Tests
+ *
+ * Validates the response shape from GET /api/users.
+ * Uses inline pure functions — no imports from app code.
+ */
+import { describe, test, expect } from 'vitest';
+
+// Expected shape of each user object
+const userSchema = {
+  id: 'string',
+  display_name: 'string',
+  email: 'string',
+};
+
+function validateUserObject(user) {
+  const errors = [];
+  for (const [field, expectedType] of Object.entries(userSchema)) {
+    if (!(field in user)) {
+      errors.push(`Missing field: ${field}`);
+    } else if (typeof user[field] !== expectedType) {
+      errors.push(`${field}: expected ${expectedType}, got ${typeof user[field]}`);
+    }
+  }
+  return errors;
+}
+
+// Mirrors the display_name extraction logic in /api/users/route.js
+function extractDisplayName(userMetadata, email) {
+  return userMetadata?.full_name || userMetadata?.name || email || 'Unknown User';
+}
+
+describe('GET /api/users response shape', () => {
+  test('valid user object passes schema', () => {
+    const user = { id: 'u-abc', display_name: 'Alice Smith', email: 'alice@example.com' };
+    expect(validateUserObject(user)).toHaveLength(0);
+  });
+
+  test('missing id fails schema', () => {
+    const user = { display_name: 'Alice', email: 'alice@example.com' };
+    const errors = validateUserObject(user);
+    expect(errors).toContain('Missing field: id');
+  });
+
+  test('missing display_name fails schema', () => {
+    const user = { id: 'u1', email: 'a@b.com' };
+    const errors = validateUserObject(user);
+    expect(errors).toContain('Missing field: display_name');
+  });
+
+  test('wrong type fails schema', () => {
+    const user = { id: 123, display_name: 'Alice', email: 'a@b.com' };
+    const errors = validateUserObject(user);
+    expect(errors).toContain('id: expected string, got number');
+  });
+});
+
+describe('extractDisplayName', () => {
+  test('prefers full_name', () => {
+    expect(extractDisplayName({ full_name: 'Alice Smith', name: 'A' }, 'a@b.com')).toBe('Alice Smith');
+  });
+
+  test('falls back to name when no full_name', () => {
+    expect(extractDisplayName({ name: 'Alice' }, 'a@b.com')).toBe('Alice');
+  });
+
+  test('falls back to email when no name metadata', () => {
+    expect(extractDisplayName({}, 'alice@example.com')).toBe('alice@example.com');
+  });
+
+  test('falls back to Unknown User when nothing available', () => {
+    expect(extractDisplayName({}, '')).toBe('Unknown User');
+  });
+
+  test('falls back to Unknown User for null metadata', () => {
+    expect(extractDisplayName(null, null)).toBe('Unknown User');
+  });
+
+  test('handles undefined metadata', () => {
+    expect(extractDisplayName(undefined, 'test@test.com')).toBe('test@test.com');
+  });
+});

--- a/tests/critical/clients/userAssignment.test.js
+++ b/tests/critical/clients/userAssignment.test.js
@@ -1,0 +1,120 @@
+/**
+ * Client User Assignment Tests
+ *
+ * Tests the logic for syncing assigned users on client create/update.
+ * Inline pure functions mirroring production logic.
+ */
+import { describe, test, expect } from 'vitest';
+
+// Mirrors POST /api/clients: resolve assigned_users from body
+function resolveAssignedUsers(assignedUsers, ownerId) {
+  if (Array.isArray(assignedUsers) && assignedUsers.length > 0) {
+    return assignedUsers;
+  }
+  return ownerId ? [ownerId] : [];
+}
+
+// Mirrors PUT /api/clients/[id]: check if user sync should run
+function shouldSyncUsers(body) {
+  return Array.isArray(body.assigned_users);
+}
+
+// Mirrors building rows for batch insert
+function buildClientUsersRows(clientId, userIds) {
+  return userIds.map((userId) => ({ client_id: clientId, user_id: userId }));
+}
+
+describe('resolveAssignedUsers (POST)', () => {
+  test('uses assigned_users when provided', () => {
+    const result = resolveAssignedUsers(['u1', 'u2'], 'u3');
+    expect(result).toEqual(['u1', 'u2']);
+  });
+
+  test('falls back to ownerId when assigned_users not provided', () => {
+    expect(resolveAssignedUsers(undefined, 'u3')).toEqual(['u3']);
+  });
+
+  test('falls back to ownerId when assigned_users is empty array', () => {
+    expect(resolveAssignedUsers([], 'u3')).toEqual(['u3']);
+  });
+
+  test('returns empty array when no ownerId and no assigned_users', () => {
+    expect(resolveAssignedUsers(undefined, null)).toEqual([]);
+  });
+
+  test('uses assigned_users even if it contains only one user', () => {
+    expect(resolveAssignedUsers(['u5'], 'u3')).toEqual(['u5']);
+  });
+
+  test('does not deduplicate — caller is responsible', () => {
+    expect(resolveAssignedUsers(['u1', 'u1'], 'u3')).toEqual(['u1', 'u1']);
+  });
+});
+
+describe('shouldSyncUsers (PUT)', () => {
+  test('syncs when assigned_users is an array', () => {
+    expect(shouldSyncUsers({ assigned_users: ['u1'] })).toBe(true);
+  });
+
+  test('syncs when assigned_users is empty array (clears all)', () => {
+    expect(shouldSyncUsers({ assigned_users: [] })).toBe(true);
+  });
+
+  test('does not sync when assigned_users is absent', () => {
+    expect(shouldSyncUsers({ name: 'Test' })).toBe(false);
+  });
+
+  test('does not sync when assigned_users is not an array', () => {
+    expect(shouldSyncUsers({ assigned_users: 'u1' })).toBe(false);
+  });
+});
+
+describe('syncUserAssignments error handling (PUT)', () => {
+  // Mirrors the PUT handler: delete failure or insert failure should signal error
+  function syncResult(deleteError, insertError, userIds) {
+    if (deleteError) return { success: false, error: 'Failed to update user assignments' };
+    if (userIds.length > 0 && insertError) return { success: false, error: 'Failed to save user assignments' };
+    return { success: true };
+  }
+
+  test('returns error when delete fails', () => {
+    const result = syncResult('delete failed', null, ['u1']);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('update user assignments');
+  });
+
+  test('returns error when insert fails after successful delete', () => {
+    const result = syncResult(null, 'insert failed', ['u1']);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('save user assignments');
+  });
+
+  test('returns success when both operations succeed', () => {
+    const result = syncResult(null, null, ['u1', 'u2']);
+    expect(result.success).toBe(true);
+  });
+
+  test('returns success when clearing all users (empty array)', () => {
+    const result = syncResult(null, null, []);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('buildClientUsersRows', () => {
+  test('builds correct rows for multiple users', () => {
+    const rows = buildClientUsersRows('c1', ['u1', 'u2']);
+    expect(rows).toEqual([
+      { client_id: 'c1', user_id: 'u1' },
+      { client_id: 'c1', user_id: 'u2' },
+    ]);
+  });
+
+  test('builds single row', () => {
+    const rows = buildClientUsersRows('c1', ['u1']);
+    expect(rows).toEqual([{ client_id: 'c1', user_id: 'u1' }]);
+  });
+
+  test('returns empty array for no users', () => {
+    expect(buildClientUsersRows('c1', [])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds multi-select user assignment field to the client add/edit form
- Displays assigned users on the client profile modal
- Extends Combobox component to support `{value, label}` object options (backward-compatible)
- Creates `GET /api/users` and `GET /api/clients/[id]/users` API routes
- Syncs `assigned_users[]` via POST/PUT client routes with error handling on failure

Relates to #61

## Test plan
- [x] Build passes (`npx next build`)
- [x] All 1556 tests pass (68 files) — `npm run test:critical && npm run test:api`
- [x] New tests: `userAssignment.test.js` (17 tests), `users.api.test.js` (10 tests), `client-users.api.test.js` (6 tests)
- [x] Updated `clients.api.test.js` with assigned_users contract tests (5 new tests)

### User Flow Verification
- [x] REQ-1: User assignment multi-select appears on add client form with all users listed
- [x] REQ-2: Edit client form shows existing assignments pre-selected as pills
- [x] REQ-3: Assigned users visible on client profile modal with avatars and display names
- [x] REQ-4: Adding a user via edit form persists the assignment after save
- [x] REQ-5: Removing a user via edit form removes the assignment after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)