### PR TITLE
feat: add user-based filtering to clients list and dashboard

### DIFF
--- a/app/clients/page.jsx
+++ b/app/clients/page.jsx
@@ -29,12 +29,14 @@ import {
 } from '@/components/ui/popover';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
-import { AlertTriangle, Loader2, Search, Plus, Filter, X, ChevronDown } from 'lucide-react';
+import { AlertTriangle, Loader2, Search, Plus, Filter, X, ChevronDown, Users } from 'lucide-react';
 import ClientProfileModal from '@/components/clients/ClientProfileModal';
 import ClientForm from '@/components/clients/ClientForm';
 import Link from 'next/link';
 import { generateClientTags, formatMatchScore, getMatchScoreBgColor } from '@/lib/utils/clientMatching';
 import { useClientMatches } from '@/lib/hooks/queries/useClients';
+import { useUsers } from '@/lib/hooks/queries/useUsers';
+import { useAuth } from '@/contexts/AuthContext';
 import { useClientsFilterStore, ITEMS_PER_PAGE } from '@/lib/stores/clientsFilterStore';
 import { queryKeys } from '@/lib/queries/queryKeys';
 
@@ -50,20 +52,32 @@ function ClientsPageContent() {
 	const searchParams = useSearchParams();
 	const router = useRouter();
 	const queryClient = useQueryClient();
-
-	// TanStack Query for data fetching
-	const { data: clientMatches = {}, isLoading: loading, error: queryError } = useClientMatches(undefined, {
-		select: (data) => data?.results || {},
-	});
-	const error = queryError?.message || null;
+	const { user } = useAuth();
 
 	// Zustand store for filter/sort state
 	const {
 		searchQuery, sortBy, filterTypes, filterStates,
-		filterHasMatches, filterDac, displayCount,
+		filterHasMatches, filterDac, filterUserId, displayCount,
 		setSearchQuery, setSortBy, setFilterTypes, setFilterStates,
-		setFilterHasMatches, setFilterDac, setDisplayCount, loadMore,
+		setFilterHasMatches, setFilterDac, setFilterUserId, setDisplayCount, loadMore,
 	} = useClientsFilterStore();
+
+	// Resolve the user_id param to send to the API
+	// null (default) = don't send param → API defaults to current user
+	// 'all' = send user_id=all → no filtering
+	// uuid = send user_id=<uuid> → specific user
+	const apiUserId = filterUserId === null ? undefined : filterUserId;
+
+	// TanStack Query for data fetching
+	const { data: clientMatches = {}, isLoading: loading, error: queryError } = useClientMatches(undefined, {
+		userId: apiUserId,
+		select: (data) => data?.results || {},
+	});
+	const error = queryError?.message || null;
+
+	// Fetch workspace users for the filter dropdown
+	const { data: usersData } = useUsers();
+	const allUsers = usersData?.users || [];
 
 	// UI-only local state
 	const [selectedClient, setSelectedClient] = useState(null);
@@ -82,6 +96,7 @@ function ClientsPageContent() {
 		const states = searchParams.get('states')?.split(',').filter(Boolean);
 		const hasMatches = searchParams.get('hasMatches');
 		const dac = searchParams.get('dac');
+		const userId = searchParams.get('userId');
 
 		if (q) setSearchQuery(q);
 		if (sort) setSortBy(sort);
@@ -89,14 +104,19 @@ function ClientsPageContent() {
 		if (states?.length) setFilterStates(states);
 		if (hasMatches) setFilterHasMatches(hasMatches);
 		if (dac) setFilterDac(dac);
-	}, [searchParams, setSearchQuery, setSortBy, setFilterTypes, setFilterStates, setFilterHasMatches, setFilterDac]);
+		if (userId) setFilterUserId(userId);
+	}, [searchParams, setSearchQuery, setSortBy, setFilterTypes, setFilterStates, setFilterHasMatches, setFilterDac, setFilterUserId]);
 
 	// Update URL when filters change
 	const updateURL = useCallback((updates) => {
 		const params = new URLSearchParams(searchParams.toString());
 
 		Object.entries(updates).forEach(([key, value]) => {
-			if (value === '' || value === 'all' || (Array.isArray(value) && value.length === 0)) {
+			// userId uses 'all' as a meaningful value (not default), so don't delete it
+			const isDefault = key === 'userId'
+				? (value === '' || value === null || value === undefined)
+				: (value === '' || value === 'all' || (Array.isArray(value) && value.length === 0));
+			if (isDefault) {
 				params.delete(key);
 			} else if (Array.isArray(value)) {
 				params.set(key, value.join(','));
@@ -207,12 +227,20 @@ function ClientsPageContent() {
 	const hasMore = displayCount < filteredAndSortedClients.length;
 	const totalCount = Object.values(clientMatches).length;
 
-	// Active filter count
+	// Active filter count (user filter counted separately since it has its own UI)
 	const activeFilterCount =
 		filterTypes.length +
 		filterStates.length +
 		(filterHasMatches !== 'all' ? 1 : 0) +
 		(filterDac !== 'all' ? 1 : 0);
+
+	// Resolve user filter display label
+	const userFilterLabel = useMemo(() => {
+		if (filterUserId === null) return 'My Clients';
+		if (filterUserId === 'all') return 'All Clients';
+		const found = allUsers.find(u => u.id === filterUserId);
+		return found?.display_name || 'Unknown User';
+	}, [filterUserId, allUsers]);
 
 	const clearAllFilters = () => {
 		setFilterTypes([]);
@@ -221,6 +249,7 @@ function ClientsPageContent() {
 		setFilterDac('all');
 		setDisplayCount(ITEMS_PER_PAGE);
 		updateURL({ types: [], states: [], hasMatches: 'all', dac: 'all' });
+		// Note: user filter is not cleared by "Clear All Filters" — it's a separate scope control
 	};
 
 	const removeFilter = (type, value) => {
@@ -396,6 +425,32 @@ function ClientsPageContent() {
 								</div>
 							</PopoverContent>
 						</Popover>
+						<Select
+							value={filterUserId === null ? '__me__' : filterUserId}
+							onValueChange={(value) => {
+								const newUserId = value === '__me__' ? null : value;
+								setFilterUserId(newUserId);
+								setDisplayCount(ITEMS_PER_PAGE);
+								updateURL({ userId: newUserId === null ? '' : newUserId });
+							}}
+						>
+							<SelectTrigger className='w-[160px]'>
+								<Users className='h-4 w-4 mr-2 flex-shrink-0' />
+								<SelectValue>{userFilterLabel}</SelectValue>
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value='__me__'>My Clients</SelectItem>
+								<SelectItem value='all'>All Clients</SelectItem>
+								{allUsers
+									.filter(u => u.id !== user?.id)
+									.map(u => (
+										<SelectItem key={u.id} value={u.id}>
+											{u.display_name}
+										</SelectItem>
+									))
+								}
+							</SelectContent>
+						</Select>
 						<Button onClick={() => setShowAddClientModal(true)}>
 							<Plus className='h-4 w-4 mr-2' />
 							Add Client
@@ -499,6 +554,9 @@ function ClientsPageContent() {
 						Showing {displayedClients.length} of {filteredAndSortedClients.length} clients
 						{filteredAndSortedClients.length !== totalCount && (
 							<span> (filtered from {totalCount} total)</span>
+						)}
+						{filterUserId !== 'all' && (
+							<span className='text-gray-400'> &middot; {userFilterLabel}</span>
 						)}
 					</div>
 				)}

--- a/app/page.js
+++ b/app/page.js
@@ -21,11 +21,14 @@ import {
 	useTopClientMatches,
 } from '@/lib/hooks/queries/useClients';
 import { useFundingCount } from '@/lib/hooks/queries/useFunding';
+import { useClientsFilterStore } from '@/lib/stores/clientsFilterStore';
 
 export default function Home() {
 	//======================================
 	// DATA FETCHING (TanStack Query)
 	//======================================
+	const filterUserId = useClientsFilterStore((s) => s.filterUserId);
+	const apiUserId = filterUserId === null ? undefined : filterUserId;
 	const { data: deadlinesData, isLoading: deadlinesLoading, error: deadlinesError } = useUpcomingDeadlines(5);
 	const upcomingDeadlines = deadlinesData?.data ?? sampleUpcomingDeadlines;
 
@@ -38,7 +41,7 @@ export default function Home() {
 	const { data: recentOppData, isLoading: recentOpportunitiesLoading, error: recentOpportunitiesError } = useRecentOpportunities();
 	const recentOpportunities = recentOppData?.data ?? sampleRecentOpportunities;
 
-	const { data: clientMatchRaw, isLoading: clientMatchesLoading } = useClientMatchSummary();
+	const { data: clientMatchRaw, isLoading: clientMatchesLoading } = useClientMatchSummary({ userId: apiUserId });
 	const clientMatchData = clientMatchRaw
 		? { clientsWithMatches: clientMatchRaw.clientsWithMatches, totalMatches: clientMatchRaw.totalMatches, totalClients: clientMatchRaw.totalClients }
 		: { clientsWithMatches: 0, totalMatches: 0, totalClients: 0 };
@@ -46,7 +49,7 @@ export default function Home() {
 	const { data: fundingData, isLoading: maxFundingLoading } = useFundingCount();
 	const maxFunding = fundingData?.total ?? 0;
 
-	const { data: topMatchesData, isLoading: topClientMatchesLoading } = useTopClientMatches();
+	const { data: topMatchesData, isLoading: topClientMatchesLoading } = useTopClientMatches({ userId: apiUserId });
 	const topClientMatches = topMatchesData?.matches ?? [];
 
 	//======================================

--- a/lib/hooks/queries/useClients.js
+++ b/lib/hooks/queries/useClients.js
@@ -9,26 +9,29 @@ import {
 } from '@/lib/queries/api';
 
 export function useClientMatches(clientId, options = {}) {
+	const { userId, ...queryOptions } = options;
 	return useQuery({
-		queryKey: queryKeys.clientMatching.matches(clientId),
-		queryFn: () => fetchClientMatching(clientId),
+		queryKey: queryKeys.clientMatching.matches(clientId, userId),
+		queryFn: () => fetchClientMatching(clientId, userId),
 		placeholderData: (prev) => prev,
-		...options,
+		...queryOptions,
 	});
 }
 
 export function useClientMatchSummary(options = {}) {
+	const { userId, ...queryOptions } = options;
 	return useQuery({
-		queryKey: queryKeys.clientMatching.summary(),
-		queryFn: fetchClientMatchingSummary,
-		...options,
+		queryKey: queryKeys.clientMatching.summary(userId),
+		queryFn: () => fetchClientMatchingSummary(userId),
+		...queryOptions,
 	});
 }
 
 export function useTopClientMatches(options = {}) {
+	const { userId, ...queryOptions } = options;
 	return useQuery({
-		queryKey: queryKeys.clientMatching.topMatches(),
-		queryFn: fetchClientMatchingTopMatches,
-		...options,
+		queryKey: queryKeys.clientMatching.topMatches(userId),
+		queryFn: () => fetchClientMatchingTopMatches(userId),
+		...queryOptions,
 	});
 }

--- a/lib/queries/api.js
+++ b/lib/queries/api.js
@@ -120,17 +120,22 @@ export async function fetchClientHiddenMatches(id) {
 // Client Matching
 // ---------------------------------------------------------------------------
 
-export async function fetchClientMatching(clientId) {
-	const params = clientId ? toParams({ clientId }) : new URLSearchParams();
+export async function fetchClientMatching(clientId, userId) {
+	const filterParams = {};
+	if (clientId) filterParams.clientId = clientId;
+	if (userId) filterParams.user_id = userId;
+	const params = toParams(filterParams);
 	return get(`/api/client-matching?${params}`);
 }
 
-export async function fetchClientMatchingSummary() {
-	return get('/api/client-matching/summary');
+export async function fetchClientMatchingSummary(userId) {
+	const params = toParams({ user_id: userId });
+	return get(`/api/client-matching/summary?${params}`);
 }
 
-export async function fetchClientMatchingTopMatches() {
-	return get('/api/client-matching/top-matches');
+export async function fetchClientMatchingTopMatches(userId) {
+	const params = toParams({ user_id: userId });
+	return get(`/api/client-matching/top-matches?${params}`);
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/queries/queryKeys.js
+++ b/lib/queries/queryKeys.js
@@ -32,9 +32,9 @@ export const queryKeys = {
 
 	clientMatching: {
 		all: ['clientMatching'],
-		matches: (clientId) => ['clientMatching', 'matches', clientId],
-		summary: () => ['clientMatching', 'summary'],
-		topMatches: () => ['clientMatching', 'topMatches'],
+		matches: (clientId, userId) => ['clientMatching', 'matches', clientId, userId],
+		summary: (userId) => ['clientMatching', 'summary', userId],
+		topMatches: (userId) => ['clientMatching', 'topMatches', userId],
 	},
 
 	dashboard: {

--- a/lib/stores/clientsFilterStore.js
+++ b/lib/stores/clientsFilterStore.js
@@ -9,6 +9,7 @@ export const DEFAULT_CLIENT_FILTERS = {
 	filterStates: [],
 	filterHasMatches: 'all',
 	filterDac: 'all',
+	filterUserId: null, // null = "my clients" (API default), 'all' = no filter, uuid = specific user
 	displayCount: ITEMS_PER_PAGE,
 };
 
@@ -21,6 +22,7 @@ export const useClientsFilterStore = create((set) => ({
 	setFilterStates: (filterStates) => set({ filterStates }),
 	setFilterHasMatches: (filterHasMatches) => set({ filterHasMatches }),
 	setFilterDac: (filterDac) => set({ filterDac }),
+	setFilterUserId: (filterUserId) => set({ filterUserId }),
 	setDisplayCount: (displayCount) => set({ displayCount }),
 	resetFilters: () => set({ ...DEFAULT_CLIENT_FILTERS }),
 	loadMore: () =>

--- a/tests/critical/hooks/query-hooks.test.js
+++ b/tests/critical/hooks/query-hooks.test.js
@@ -34,9 +34,9 @@ const queryKeys = {
 	},
 	clientMatching: {
 		all: ['clientMatching'],
-		matches: (clientId) => ['clientMatching', 'matches', clientId],
-		summary: () => ['clientMatching', 'summary'],
-		topMatches: () => ['clientMatching', 'topMatches'],
+		matches: (clientId, userId) => ['clientMatching', 'matches', clientId, userId],
+		summary: (userId) => ['clientMatching', 'summary', userId],
+		topMatches: (userId) => ['clientMatching', 'topMatches', userId],
 	},
 	dashboard: {
 		all: ['dashboard'],
@@ -144,24 +144,27 @@ function buildCategoryMappingConfig(options = {}) {
 }
 
 function buildClientMatchesConfig(clientId, options = {}) {
+	const { userId, ...rest } = options;
 	return {
-		queryKey: queryKeys.clientMatching.matches(clientId),
+		queryKey: queryKeys.clientMatching.matches(clientId, userId),
 		hasPlaceholderData: true,
-		...options,
+		...rest,
 	};
 }
 
 function buildClientMatchSummaryConfig(options = {}) {
+	const { userId, ...rest } = options;
 	return {
-		queryKey: queryKeys.clientMatching.summary(),
-		...options,
+		queryKey: queryKeys.clientMatching.summary(userId),
+		...rest,
 	};
 }
 
 function buildTopClientMatchesConfig(options = {}) {
+	const { userId, ...rest } = options;
 	return {
-		queryKey: queryKeys.clientMatching.topMatches(),
-		...options,
+		queryKey: queryKeys.clientMatching.topMatches(userId),
+		...rest,
 	};
 }
 
@@ -348,23 +351,43 @@ describe('useCategoryMapping select transform', () => {
 describe('useClients hooks', () => {
 	test('useClientMatches uses clientMatching.matches key', () => {
 		const config = buildClientMatchesConfig('client-1');
-		expect(config.queryKey).toEqual(['clientMatching', 'matches', 'client-1']);
+		expect(config.queryKey).toEqual(['clientMatching', 'matches', 'client-1', undefined]);
 		expect(config.hasPlaceholderData).toBe(true);
 	});
 
 	test('useClientMatches with undefined clientId fetches all', () => {
 		const config = buildClientMatchesConfig(undefined);
-		expect(config.queryKey).toEqual(['clientMatching', 'matches', undefined]);
+		expect(config.queryKey).toEqual(['clientMatching', 'matches', undefined, undefined]);
+	});
+
+	test('useClientMatches with userId scopes cache per user', () => {
+		const config = buildClientMatchesConfig(undefined, { userId: 'user-abc' });
+		expect(config.queryKey).toEqual(['clientMatching', 'matches', undefined, 'user-abc']);
+	});
+
+	test('useClientMatches with "all" userId fetches all clients', () => {
+		const config = buildClientMatchesConfig(undefined, { userId: 'all' });
+		expect(config.queryKey).toEqual(['clientMatching', 'matches', undefined, 'all']);
 	});
 
 	test('useClientMatchSummary uses clientMatching.summary key', () => {
 		const config = buildClientMatchSummaryConfig();
-		expect(config.queryKey).toEqual(['clientMatching', 'summary']);
+		expect(config.queryKey).toEqual(['clientMatching', 'summary', undefined]);
+	});
+
+	test('useClientMatchSummary with userId scopes cache', () => {
+		const config = buildClientMatchSummaryConfig({ userId: 'user-abc' });
+		expect(config.queryKey).toEqual(['clientMatching', 'summary', 'user-abc']);
 	});
 
 	test('useTopClientMatches uses clientMatching.topMatches key', () => {
 		const config = buildTopClientMatchesConfig();
-		expect(config.queryKey).toEqual(['clientMatching', 'topMatches']);
+		expect(config.queryKey).toEqual(['clientMatching', 'topMatches', undefined]);
+	});
+
+	test('useTopClientMatches with userId scopes cache', () => {
+		const config = buildTopClientMatchesConfig({ userId: 'all' });
+		expect(config.queryKey).toEqual(['clientMatching', 'topMatches', 'all']);
 	});
 });
 

--- a/tests/critical/stores/clientsFilterStore.test.js
+++ b/tests/critical/stores/clientsFilterStore.test.js
@@ -9,6 +9,7 @@ const DEFAULT_CLIENT_FILTERS = {
 	filterStates: [],
 	filterHasMatches: 'all',
 	filterDac: 'all',
+	filterUserId: null,
 	displayCount: ITEMS_PER_PAGE,
 };
 
@@ -40,6 +41,10 @@ describe('clientsFilterStore', () => {
 		it('has "all" as default for toggle filters', () => {
 			expect(DEFAULT_CLIENT_FILTERS.filterHasMatches).toBe('all');
 			expect(DEFAULT_CLIENT_FILTERS.filterDac).toBe('all');
+		});
+
+		it('has null as default filterUserId (my clients)', () => {
+			expect(DEFAULT_CLIENT_FILTERS.filterUserId).toBeNull();
 		});
 
 		it('has ITEMS_PER_PAGE as default displayCount', () => {
@@ -97,6 +102,22 @@ describe('clientsFilterStore', () => {
 			}
 		});
 
+		it('setFilterUserId sets to "all" for all clients', () => {
+			const state = { ...DEFAULT_CLIENT_FILTERS, filterUserId: 'all' };
+			expect(state.filterUserId).toBe('all');
+		});
+
+		it('setFilterUserId sets to uuid for specific user', () => {
+			const uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+			const state = { ...DEFAULT_CLIENT_FILTERS, filterUserId: uuid };
+			expect(state.filterUserId).toBe(uuid);
+		});
+
+		it('setFilterUserId sets to null for my clients', () => {
+			const state = { ...DEFAULT_CLIENT_FILTERS, filterUserId: null };
+			expect(state.filterUserId).toBeNull();
+		});
+
 		it('setDisplayCount updates count', () => {
 			const state = { ...DEFAULT_CLIENT_FILTERS, displayCount: 24 };
 			expect(state.displayCount).toBe(24);
@@ -112,6 +133,56 @@ describe('clientsFilterStore', () => {
 		it('resets displayCount to ITEMS_PER_PAGE', () => {
 			const result = resetFilters();
 			expect(result.displayCount).toBe(ITEMS_PER_PAGE);
+		});
+	});
+
+	describe('userFilterLabel', () => {
+		// Inline function matching the page's useMemo logic
+		function getUserFilterLabel(filterUserId, allUsers) {
+			if (filterUserId === null) return 'My Clients';
+			if (filterUserId === 'all') return 'All Clients';
+			const found = allUsers.find(u => u.id === filterUserId);
+			return found?.display_name || 'Unknown User';
+		}
+
+		it('returns "My Clients" when filterUserId is null', () => {
+			expect(getUserFilterLabel(null, [])).toBe('My Clients');
+		});
+
+		it('returns "All Clients" when filterUserId is "all"', () => {
+			expect(getUserFilterLabel('all', [])).toBe('All Clients');
+		});
+
+		it('returns user display name for matching uuid', () => {
+			const users = [{ id: 'abc', display_name: 'Jane Doe' }];
+			expect(getUserFilterLabel('abc', users)).toBe('Jane Doe');
+		});
+
+		it('returns "Unknown User" for unrecognized uuid', () => {
+			expect(getUserFilterLabel('xyz', [])).toBe('Unknown User');
+		});
+	});
+
+	describe('resolveApiUserId', () => {
+		// Inline function matching the page logic:
+		// null → undefined (API defaults to current user)
+		// 'all' → 'all' (API returns all clients)
+		// uuid → uuid (API filters by that user)
+		function resolveApiUserId(filterUserId) {
+			return filterUserId === null ? undefined : filterUserId;
+		}
+
+		it('null maps to undefined (API default = my clients)', () => {
+			expect(resolveApiUserId(null)).toBeUndefined();
+		});
+
+		it('"all" passes through as "all"', () => {
+			expect(resolveApiUserId('all')).toBe('all');
+		});
+
+		it('uuid passes through as-is', () => {
+			const uuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+			expect(resolveApiUserId(uuid)).toBe(uuid);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Add user filter dropdown (My Clients / All Clients / specific user) to the clients page header
- Wire `userId` through Zustand store, query keys, fetch functions, and React Query hooks for per-user cache scoping
- Dashboard stats respect the active user filter
- URL param sync (`?userId=all`) for bookmarkability

Relates to #62

## Test plan
- [x] 1276 critical tests pass
- [x] 295 API tests pass
- [x] Build compiles clean
- [x] Browser verified: default "My Clients", switch to "All Clients", URL persistence, navigation persistence
- [x] Code review: clean (minor import consolidation applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)