### PR TITLE
Fix client budget: align DB and API with tier-string UI

### DIFF
--- a/app/api/clients/[id]/route.js
+++ b/app/api/clients/[id]/route.js
@@ -89,11 +89,12 @@ export async function PUT(request, { params }) {
       throw fetchError;
     }
 
-    // Parse budget as numeric value (or null if not provided)
+    // Validate budget tier string (or null if not provided)
+    const VALID_BUDGET_TIERS = ['small', 'medium', 'large', 'very_large'];
     let budget = null;
     if (body.budget !== null && body.budget !== undefined && body.budget !== '') {
-      budget = typeof body.budget === 'number' ? body.budget : parseFloat(body.budget);
-      if (isNaN(budget)) {
+      budget = String(body.budget);
+      if (!VALID_BUDGET_TIERS.includes(budget)) {
         budget = null;
       }
     }

--- a/app/api/clients/route.js
+++ b/app/api/clients/route.js
@@ -157,26 +157,17 @@ export async function POST(request) {
     console.log(`[API] Found ${coverageAreaIds.length} coverage areas`);
 
     // Step 3: Insert client into database
-    // Parse budget as numeric value (or null if not provided)
+    // Validate budget tier string (or null if not provided)
+    const VALID_BUDGET_TIERS = ['small', 'medium', 'large', 'very_large'];
     let budget = null;
     if (body.budget !== null && body.budget !== undefined && body.budget !== '') {
-      budget = typeof body.budget === 'number' ? body.budget : parseFloat(body.budget);
-      if (isNaN(budget)) {
-        console.error('[API] Invalid budget value:', body.budget);
+      budget = String(body.budget);
+      if (!VALID_BUDGET_TIERS.includes(budget)) {
+        console.error('[API] Invalid budget tier:', body.budget);
         return NextResponse.json(
           {
             success: false,
-            error: `Invalid budget value: ${body.budget}. Please enter a valid number.`
-          },
-          { status: 400 }
-        );
-      }
-      if (budget < 0) {
-        console.error('[API] Negative budget value:', budget);
-        return NextResponse.json(
-          {
-            success: false,
-            error: 'Budget cannot be negative'
+            error: `Invalid budget tier: ${body.budget}. Must be one of: ${VALID_BUDGET_TIERS.join(', ')}`
           },
           { status: 400 }
         );

--- a/supabase/migrations/20260312000001_change_budget_to_text.sql
+++ b/supabase/migrations/20260312000001_change_budget_to_text.sql
@@ -1,0 +1,21 @@
+-- Migration: Change budget column from NUMERIC back to TEXT for tier-based values
+-- Reason: UI redesign now uses tier strings (small, medium, large, very_large)
+-- instead of raw numeric values. The API routes and display components all work
+-- in tier-string terms.
+
+-- Step 1: Convert existing numeric values to tier strings based on the original ranges
+ALTER TABLE clients ALTER COLUMN budget TYPE TEXT USING
+  CASE
+    WHEN budget IS NULL THEN NULL
+    WHEN budget < 500000 THEN 'small'
+    WHEN budget < 5000000 THEN 'medium'
+    WHEN budget < 50000000 THEN 'large'
+    ELSE 'very_large'
+  END;
+
+-- Step 2: Add a CHECK constraint for valid tier values
+ALTER TABLE clients ADD CONSTRAINT clients_budget_tier_check
+  CHECK (budget IS NULL OR budget IN ('small', 'medium', 'large', 'very_large'));
+
+-- Step 3: Update column comment
+COMMENT ON COLUMN clients.budget IS 'Client budget tier: small ($50K-$500K), medium ($500K-$5M), large ($5M-$50M), very_large ($50M+)';

--- a/tests/critical/clients/crud.test.js
+++ b/tests/critical/clients/crud.test.js
@@ -34,8 +34,9 @@ function validateClient(data) {
   }
 
   if (data.budget !== undefined && data.budget !== null) {
-    if (typeof data.budget !== 'number' || data.budget < 0) {
-      errors.push({ field: 'budget', message: 'Budget must be a positive number' });
+    const VALID_BUDGET_TIERS = ['small', 'medium', 'large', 'very_large'];
+    if (typeof data.budget !== 'string' || !VALID_BUDGET_TIERS.includes(data.budget)) {
+      errors.push({ field: 'budget', message: 'Budget must be a valid tier: small, medium, large, very_large' });
     }
   }
 
@@ -141,24 +142,34 @@ describe('Client CRUD', () => {
       );
     });
 
-    test('negative budget produces error', () => {
+    test('valid budget tier produces no error', () => {
       const errors = validateClient({
         name: 'Test',
         type: 'Test',
         state_code: 'CA',
-        budget: -1000,
+        budget: 'medium',
+      });
+      expect(errors.filter(e => e.field === 'budget')).toHaveLength(0);
+    });
+
+    test('invalid budget tier produces error', () => {
+      const errors = validateClient({
+        name: 'Test',
+        type: 'Test',
+        state_code: 'CA',
+        budget: 'extra_large',
       });
       expect(errors).toContainEqual(
         expect.objectContaining({ field: 'budget' })
       );
     });
 
-    test('string budget produces error', () => {
+    test('numeric budget produces error', () => {
       const errors = validateClient({
         name: 'Test',
         type: 'Test',
         state_code: 'CA',
-        budget: '5000',
+        budget: 5000,
       });
       expect(errors).toContainEqual(
         expect.objectContaining({ field: 'budget' })


### PR DESCRIPTION
## Summary
- The client form redesign (commit 36c9036) switched budget from a numeric input to a tier-string Combobox (`small`, `medium`, `large`, `very_large`), but the DB column remained NUMERIC and API routes still called `parseFloat()` — causing creates to fail with 400 and edits to silently null out the budget.
- Migrates `clients.budget` from NUMERIC to TEXT, mapping existing numeric values to tier strings
- Updates POST and PUT routes to validate tier strings instead of numeric values
- Updates inline test functions and cases to match new tier-based validation

## Test plan
- [x] 1277/1277 critical tests pass
- [x] Migration applies cleanly (`supabase migration up`)
- [x] Add Client form: budget tier dropdown renders and selects correctly
- [x] Client profile modal: displays tier label (e.g., "Large ($5M - $50M)")
- [x] Zero console errors

Relates to #69