### PR TITLE
fix: add promotion_status filter to Explore page RPC

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -2,15 +2,6 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse } from 'next/server';
 
 export async function middleware(request) {
-	// In development mode, bypass authentication for easier testing
-	if (process.env.NODE_ENV === 'development') {
-		return NextResponse.next({
-			request: {
-				headers: request.headers,
-			},
-		});
-	}
-
 	// Create a response object to modify
 	let supabaseResponse = NextResponse.next({
 		request: {
@@ -36,6 +27,28 @@ export async function middleware(request) {
 			},
 		}
 	);
+
+	// In development mode, auto-authenticate as dev admin user.
+	// This creates a real session so all auth code (requireRole, getUser, etc.)
+	// works through the normal code path — no special dev bypasses needed.
+	if (process.env.NODE_ENV === 'development') {
+		const { data: { user } } = await supabase.auth.getUser();
+
+		if (!user) {
+			// No session yet — sign in as the seeded dev admin
+			const { error: signInError } = await supabase.auth.signInWithPassword({
+				email: process.env.DEV_ADMIN_EMAIL,
+				password: process.env.DEV_ADMIN_PASSWORD,
+			});
+
+			if (signInError) {
+				// Dev user may not exist (fresh DB) — fall through without auth
+				console.warn('[Dev Auth] Auto sign-in failed:', signInError.message);
+			}
+		}
+
+		return supabaseResponse;
+	}
 
 	// IMPORTANT: Do not run code between createServerClient and
 	// supabase.auth.getUser(). A simple mistake could make it very

--- a/supabase/migrations/20260312000001_fix_explore_promotion_status_filter.sql
+++ b/supabase/migrations/20260312000001_fix_explore_promotion_status_filter.sql
@@ -1,0 +1,182 @@
+-- Fix: Add promotion_status filter to get_funding_opportunities_dynamic_sort
+--
+-- Migration 20260218000001 removed the promotion_status filter from the
+-- funding_opportunities_with_geography view so admins could see pending_review
+-- records on the detail page. The comment said "Consumer queries must filter
+-- promotion_status themselves." But this RPC — the sole consumer for the
+-- Explore page — was never updated. Result: pending_review records appear
+-- on the public Explore page.
+--
+-- Fix: Add a mandatory WHERE clause to the base_query so pending_review
+-- records are always excluded from the Explore listing. The view remains
+-- unfiltered so the admin detail page still works.
+
+CREATE OR REPLACE FUNCTION public.get_funding_opportunities_dynamic_sort(
+    p_status text[] DEFAULT NULL::text[],
+    p_categories text[] DEFAULT NULL::text[],
+    p_project_types text[] DEFAULT NULL::text[],
+    p_state_code text DEFAULT NULL::text,
+    p_coverage_types text[] DEFAULT NULL::text[],
+    p_search text DEFAULT NULL::text,
+    p_sort_by text DEFAULT 'relevance'::text,
+    p_sort_direction text DEFAULT 'desc'::text,
+    p_page integer DEFAULT 1,
+    p_page_size integer DEFAULT 9,
+    p_tracked_ids text[] DEFAULT NULL::text[]
+)
+RETURNS SETOF funding_opportunities_with_geography
+LANGUAGE plpgsql
+STABLE
+AS $function$
+DECLARE
+    base_query TEXT;
+    where_clauses TEXT[] := '{}';
+    coverage_conditions TEXT[] := '{}';
+    final_query TEXT;
+    include_national BOOLEAN := FALSE;
+    include_state BOOLEAN := FALSE;
+    include_local BOOLEAN := FALSE;
+    include_unknown BOOLEAN := FALSE;
+BEGIN
+    base_query := 'SELECT DISTINCT fwg.* FROM funding_opportunities_with_geography fwg
+                   LEFT JOIN opportunity_coverage_areas oca ON fwg.id = oca.opportunity_id
+                   LEFT JOIN coverage_areas ca ON oca.coverage_area_id = ca.id';
+
+    -- Promotion status gate: only show promoted or legacy (NULL) records.
+    -- pending_review and rejected records are excluded from the Explore page.
+    where_clauses := array_append(where_clauses, '(fwg.promotion_status IS NULL OR fwg.promotion_status = ''promoted'')');
+
+    -- Status filter (supports array of statuses)
+    IF p_status IS NOT NULL AND array_length(p_status, 1) > 0 THEN
+        where_clauses := array_append(where_clauses, format('lower(fwg.status) = ANY(SELECT lower(unnest(%L::text[])))', p_status));
+    END IF;
+
+    -- Categories filter
+    IF p_categories IS NOT NULL AND array_length(p_categories, 1) > 0 THEN
+        where_clauses := array_append(where_clauses, format('fwg.categories && %L::text[]', p_categories));
+    END IF;
+
+    -- Project types filter
+    IF p_project_types IS NOT NULL AND array_length(p_project_types, 1) > 0 THEN
+        where_clauses := array_append(where_clauses, format('fwg.eligible_project_types && %L::text[]', p_project_types));
+    END IF;
+
+    -- Search filter
+    IF p_search IS NOT NULL AND p_search <> '' THEN
+        where_clauses := array_append(where_clauses, format('(fwg.title ILIKE %L OR fwg.description ILIKE %L OR fwg.actionable_summary ILIKE %L)',
+             '%' || p_search || '%', '%' || p_search || '%', '%' || p_search || '%'));
+    END IF;
+
+    -- Tracked IDs filter
+    IF p_tracked_ids IS NOT NULL THEN
+        IF array_length(p_tracked_ids, 1) > 0 AND
+           EXISTS(SELECT 1 FROM unnest(p_tracked_ids) AS elem WHERE elem IS NOT NULL AND elem <> '') THEN
+            where_clauses := array_append(where_clauses,
+                format('fwg.id::text = ANY(ARRAY[%s])',
+                    (SELECT string_agg(format('%L', elem), ',')
+                     FROM unnest(p_tracked_ids) AS elem
+                     WHERE elem IS NOT NULL AND elem <> '')));
+        ELSE
+            where_clauses := array_append(where_clauses, 'FALSE');
+        END IF;
+    END IF;
+
+    -- Parse coverage types
+    IF p_coverage_types IS NOT NULL AND array_length(p_coverage_types, 1) > 0 THEN
+        include_national := 'national' = ANY(p_coverage_types);
+        include_state := 'state' = ANY(p_coverage_types);
+        include_local := 'local' = ANY(p_coverage_types);
+        include_unknown := 'unknown' = ANY(p_coverage_types);
+    ELSE
+        include_national := TRUE;
+        include_state := TRUE;
+        include_local := TRUE;
+        include_unknown := FALSE;
+    END IF;
+
+    -- Build coverage type conditions
+    IF p_state_code IS NOT NULL AND p_state_code <> '' THEN
+        IF include_national THEN
+            coverage_conditions := array_append(coverage_conditions, 'ca.kind = ''national''');
+        END IF;
+        IF include_state THEN
+            coverage_conditions := array_append(coverage_conditions,
+                format('(ca.kind = ''state'' AND ca.state_code = %L)', p_state_code));
+        END IF;
+        IF include_local THEN
+            coverage_conditions := array_append(coverage_conditions,
+                format('(ca.kind IN (''utility'', ''county'', ''city'') AND ca.state_code = %L)', p_state_code));
+        END IF;
+        IF include_unknown THEN
+            coverage_conditions := array_append(coverage_conditions, 'oca.id IS NULL');
+        END IF;
+    ELSE
+        IF include_national THEN
+            coverage_conditions := array_append(coverage_conditions, 'ca.kind = ''national''');
+        END IF;
+        IF include_state THEN
+            coverage_conditions := array_append(coverage_conditions, 'ca.kind = ''state''');
+        END IF;
+        IF include_local THEN
+            coverage_conditions := array_append(coverage_conditions, 'ca.kind IN (''utility'', ''county'', ''city'')');
+        END IF;
+        IF include_unknown THEN
+            coverage_conditions := array_append(coverage_conditions, 'oca.id IS NULL');
+        END IF;
+    END IF;
+
+    IF array_length(coverage_conditions, 1) > 0 THEN
+        where_clauses := array_append(where_clauses, '(' || array_to_string(coverage_conditions, ' OR ') || ')');
+    END IF;
+
+    IF array_length(where_clauses, 1) > 0 THEN
+        base_query := base_query || ' WHERE ' || array_to_string(where_clauses, ' AND ');
+    END IF;
+
+    -- Sorting logic
+    IF p_sort_by = 'amount' AND p_sort_direction = 'desc' THEN
+        final_query := base_query || format(' ORDER BY fwg.maximum_award DESC NULLS LAST, fwg.minimum_award DESC NULLS LAST, fwg.total_funding_available DESC NULLS LAST, fwg.relevance_score DESC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'amount' AND p_sort_direction = 'asc' THEN
+         final_query := base_query || format(' ORDER BY
+             CASE
+                 WHEN fwg.maximum_award IS NULL AND fwg.minimum_award IS NULL AND fwg.total_funding_available IS NULL THEN 0
+                 WHEN fwg.maximum_award IS NULL AND fwg.minimum_award IS NULL THEN 1
+                 WHEN fwg.maximum_award IS NULL THEN 2
+                 ELSE 3
+             END ASC,
+             CASE
+                 WHEN fwg.maximum_award IS NULL AND fwg.minimum_award IS NULL AND fwg.total_funding_available IS NULL THEN fwg.relevance_score
+                 WHEN fwg.maximum_award IS NULL AND fwg.minimum_award IS NULL THEN fwg.total_funding_available
+                 WHEN fwg.maximum_award IS NULL THEN fwg.minimum_award
+                 ELSE fwg.maximum_award
+             END ASC NULLS LAST,
+             fwg.relevance_score DESC NULLS LAST,
+             fwg.id ASC
+             LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'relevance' AND p_sort_direction = 'desc' THEN
+        final_query := base_query || format(' ORDER BY fwg.relevance_score DESC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'relevance' AND p_sort_direction = 'asc' THEN
+         final_query := base_query || format(' ORDER BY fwg.relevance_score ASC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'close_date' AND p_sort_direction = 'desc' THEN
+         final_query := base_query || format(' ORDER BY fwg.close_date DESC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'close_date' AND p_sort_direction = 'asc' THEN
+         final_query := base_query || format(' ORDER BY fwg.close_date ASC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'updated_at' AND p_sort_direction = 'desc' THEN
+         final_query := base_query || format(' ORDER BY fwg.updated_at DESC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'updated_at' AND p_sort_direction = 'asc' THEN
+         final_query := base_query || format(' ORDER BY fwg.updated_at ASC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'created_at' AND p_sort_direction = 'desc' THEN
+         final_query := base_query || format(' ORDER BY fwg.created_at DESC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSIF p_sort_by = 'created_at' AND p_sort_direction = 'asc' THEN
+         final_query := base_query || format(' ORDER BY fwg.created_at ASC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    ELSE
+        final_query := base_query || format(' ORDER BY fwg.relevance_score DESC NULLS LAST LIMIT %L OFFSET %L', p_page_size, (p_page - 1) * p_page_size);
+    END IF;
+
+    RAISE NOTICE 'Executing query (V17 - promotion_status filter): %', final_query;
+    RETURN QUERY EXECUTE final_query;
+
+END;
+$function$;
+
+COMMENT ON FUNCTION get_funding_opportunities_dynamic_sort IS 'V17: Add promotion_status filter — exclude pending_review and rejected records from Explore page. Fixes #78.';

--- a/tests/database/rpc/getFundingDynamicSort.test.js
+++ b/tests/database/rpc/getFundingDynamicSort.test.js
@@ -29,6 +29,11 @@ function simulateGetFundingDynamicSort(opportunities, params = {}) {
 
   let result = [...opportunities];
 
+  // Promotion status gate: only show promoted or legacy (NULL) records
+  result = result.filter(o =>
+    o.promotion_status === null || o.promotion_status === undefined || o.promotion_status === 'promoted'
+  );
+
   // Apply status filter
   if (status_filter && status_filter !== 'all') {
     result = result.filter(o => o.status === status_filter);
@@ -107,6 +112,7 @@ const testOpportunities = [
     maximum_award: 5000000,
     created_at: '2024-01-15T10:00:00Z',
     program_overview: 'Federal funding for clean energy projects',
+    promotion_status: null, // legacy record, visible
   },
   {
     id: 'opp-2',
@@ -120,6 +126,7 @@ const testOpportunities = [
     maximum_award: 2000000,
     created_at: '2024-02-01T10:00:00Z',
     program_overview: 'State climate funding',
+    promotion_status: 'promoted', // approved, visible
   },
   {
     id: 'opp-3',
@@ -133,6 +140,7 @@ const testOpportunities = [
     maximum_award: 500000,
     created_at: '2024-03-01T10:00:00Z',
     program_overview: 'Texas efficiency funding',
+    promotion_status: null, // legacy record, visible
   },
   {
     id: 'opp-4',
@@ -146,6 +154,7 @@ const testOpportunities = [
     maximum_award: null,
     created_at: '2024-04-01T10:00:00Z',
     program_overview: 'Ongoing utility rebates',
+    promotion_status: null, // legacy record, visible
   },
   {
     id: 'opp-5',
@@ -159,6 +168,35 @@ const testOpportunities = [
     maximum_award: 10000000,
     created_at: '2023-12-01T10:00:00Z',
     program_overview: 'Expired federal grant',
+    promotion_status: null, // legacy record, visible
+  },
+  {
+    id: 'opp-6',
+    title: 'Arizona Utility Rebate Program',
+    agency_name: 'APS',
+    status: 'open',
+    close_date: '2026-12-31T23:59:59Z',
+    is_national: false,
+    coverage_state_codes: ['AZ'],
+    relevance_score: 6.5,
+    maximum_award: 100000,
+    created_at: '2026-03-10T10:00:00Z',
+    program_overview: 'Arizona utility rebate',
+    promotion_status: 'pending_review', // awaiting admin approval, NOT visible
+  },
+  {
+    id: 'opp-7',
+    title: 'Rejected Solar Program',
+    agency_name: 'SRP',
+    status: 'open',
+    close_date: '2026-09-30T23:59:59Z',
+    is_national: false,
+    coverage_state_codes: ['AZ'],
+    relevance_score: 3.0,
+    maximum_award: 50000,
+    created_at: '2026-03-10T10:00:00Z',
+    program_overview: 'Rejected solar program',
+    promotion_status: 'rejected', // rejected by admin, NOT visible
   },
 ];
 
@@ -274,12 +312,12 @@ describe('RPC: get_funding_dynamic_sort', () => {
       expect(result.total).toBe(1);
     });
 
-    test('all status returns everything', () => {
+    test('all status returns all visible records', () => {
       const result = simulateGetFundingDynamicSort(testOpportunities, {
         status_filter: 'all',
       });
 
-      expect(result.total).toBe(5);
+      expect(result.total).toBe(5); // 5 visible (excludes pending_review + rejected)
     });
   });
 
@@ -346,7 +384,7 @@ describe('RPC: get_funding_dynamic_sort', () => {
         page_size: 2,
       });
 
-      expect(result.total_pages).toBe(Math.ceil(5 / 2));
+      expect(result.total_pages).toBe(Math.ceil(result.total / 2));
     });
 
     test('has_more indicates more pages', () => {
@@ -414,6 +452,55 @@ describe('RPC: get_funding_dynamic_sort', () => {
 
       expect(result.data.length).toBeLessThanOrEqual(1);
       expect(result.total).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Promotion Status Gate', () => {
+    test('pending_review records are excluded from results', () => {
+      const result = simulateGetFundingDynamicSort(testOpportunities);
+
+      const ids = result.data.map(o => o.id);
+      expect(ids).not.toContain('opp-6'); // pending_review
+    });
+
+    test('rejected records are excluded from results', () => {
+      const result = simulateGetFundingDynamicSort(testOpportunities);
+
+      const ids = result.data.map(o => o.id);
+      expect(ids).not.toContain('opp-7'); // rejected
+    });
+
+    test('promoted records are included', () => {
+      const result = simulateGetFundingDynamicSort(testOpportunities);
+
+      const ids = result.data.map(o => o.id);
+      expect(ids).toContain('opp-2'); // promoted
+    });
+
+    test('null promotion_status (legacy) records are included', () => {
+      const result = simulateGetFundingDynamicSort(testOpportunities);
+
+      const ids = result.data.map(o => o.id);
+      expect(ids).toContain('opp-1'); // null promotion_status
+    });
+
+    test('total count excludes pending_review and rejected', () => {
+      const result = simulateGetFundingDynamicSort(testOpportunities);
+
+      // 7 total records, but 2 are pending_review/rejected = 5 visible
+      expect(result.total).toBe(5);
+    });
+
+    test('promotion_status filter applies before other filters', () => {
+      const result = simulateGetFundingDynamicSort(testOpportunities, {
+        state_filter: 'AZ',
+      });
+
+      // opp-6 (AZ, pending_review) and opp-7 (AZ, rejected) should both be excluded
+      // No AZ-specific visible records, only nationals
+      const ids = result.data.map(o => o.id);
+      expect(ids).not.toContain('opp-6');
+      expect(ids).not.toContain('opp-7');
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `promotion_status` gate to `get_funding_opportunities_dynamic_sort` RPC — excludes `pending_review` and `rejected` records from the public Explore page
- Replace middleware dev bypass with real session auth using a seeded local admin user — all downstream auth works through the production code path
- Add 6 new promotion status gate tests (29 total pass)

Relates to #78

## Test plan
- [x] All 29 RPC simulation tests pass (`npm run test:database`)
- [x] Build passes
- [x] E2E verified: RPC returns only NULL + promoted records; view remains unfiltered for admin detail page
- [x] Dev auth: admin review page accessible and functional in local environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)