### PR TITLE
chore: switch pipeline agents to Sonnet for cost optimization

### DIFF
--- a/.claude/agents/extraction-agent.md
+++ b/.claude/agents/extraction-agent.md
@@ -6,7 +6,7 @@ description: >
   JSONB, stores raw_content, computes source_hash, and updates extraction_status.
   Source-type agnostic — handles utilities, state agencies, counties,
   municipalities, foundations, and federal sources.
-model: opus
+model: sonnet
 skills:
   - extraction
 ---

--- a/.claude/agents/opportunity-discovery-agent.md
+++ b/.claude/agents/opportunity-discovery-agent.md
@@ -6,7 +6,7 @@ description: >
   creates staging records for opportunities found, and updates program
   scheduling (next_check_at). Use as Agent Team teammate or standalone
   via Task tool.
-model: opus
+model: sonnet
 skills:
   - opportunity-discovery
 ---

--- a/.claude/agents/program-discovery-agent.md
+++ b/.claude/agents/program-discovery-agent.md
@@ -6,7 +6,7 @@ description: >
   extracts structured program data, and registers programs in funding_programs.
   Operates in two modes: Scout (find programs) or Extractor (extract + store).
   Use as Agent Team teammate or standalone via Task tool.
-model: opus
+model: sonnet
 skills:
   - program-discovery
 ---

--- a/.claude/agents/source-registry-agent.md
+++ b/.claude/agents/source-registry-agent.md
@@ -5,7 +5,7 @@ description: >
   Discovers and registers funding entities (utilities, state agencies,
   foundations, counties, tribal authorities) via multi-strategy web search.
   Use as Agent Team teammate or standalone via Task tool for source registration.
-model: opus
+model: sonnet
 skills:
   - source-registry
 ---

--- a/.claude/agents/storage-agent.md
+++ b/.claude/agents/storage-agent.md
@@ -4,7 +4,7 @@ description: >
   Phase 6 storage agent for the manual funding pipeline. Sanitizes analysis_data,
   UPSERTs to funding_opportunities with promotion_status='pending_review',
   links coverage areas, and updates staging status.
-model: opus
+model: sonnet
 skills:
   - storage
 ---

--- a/.claude/skills/extraction/SKILL.md
+++ b/.claude/skills/extraction/SKILL.md
@@ -37,24 +37,46 @@ You need all five taxonomy categories memorized:
 
 Use this decision tree for ALL URL fetching.
 
-### HTML Pages (~70% of URLs)
+### HTML Pages — Detection-Based Routing
 
 ```
-1. WebFetch(url)
-   → If content looks complete (has program details, not just nav/headers) → DONE
-2. If WebFetch returns empty/minimal/garbled content (JS-rendered page):
-   → Playwright: mcp__playwright__browser_navigate(url) + browser_snapshot()
-3. If Playwright also fails:
-   → FLAG as "JS-rendered, could not extract" — never silently skip
+1. Try WebFetch(url)
+
+2. Read the response. Route based on what you see:
+
+   a) Content looks complete (body text > 500 chars, has program details)
+      → DONE. Use this content.
+
+   b) HTTP 403, or response contains "Access Denied" / "edgesuite" / "Akamai"
+      → Akamai bot protection. Try:
+        curl -sL -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
+             AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+             -H "Accept: text/html" -H "Accept-Language: en-US,en" --compressed "URL"
+        If curl also returns 403 → use Playwright:
+          mcp__playwright__browser_navigate(url) + browser_snapshot()
+
+   c) Response is small (< 500 chars body) with <script> tags referencing
+      CMS frameworks ("civicplus", "requirejs", "vision-cms", "granicus")
+      → JS-rendered CMS. Try curl with User-Agent header (same as above).
+        If curl returns same thin content → use Playwright.
+
+   d) Response contains "Just a moment" / "Checking your browser" / "cf-"
+      → Cloudflare challenge. Skip curl, go directly to Playwright.
+
+   e) curl with headers also returns 403 AND Playwright also fails
+      → FLAG as unreachable: "Content retrieval failed after WebFetch +
+        curl + Playwright. Needs manual review." Never silently skip.
 ```
 
-### PDF Documents (~10% of URLs)
+No per-site lookup tables needed. The agent reads the rejection signal and adapts.
 
-**Do NOT use WebFetch for PDFs** — it returns garbled binary.
+### PDF Documents
+
+**Never use WebFetch for PDFs** — it returns garbled binary. Always use curl piped
+to PyMuPDF:
 
 ```bash
-# Pipe directly — zero temp files
-# ALWAYS include User-Agent header (many gov sites block bare curl)
+# Always include User-Agent header — many gov sites block bare curl
 curl -sL -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" "PDF_URL" | python3 -c "
 import sys, fitz
 doc = fitz.open(stream=sys.stdin.buffer.read(), filetype='pdf')
@@ -63,11 +85,14 @@ for page in doc: print(page.get_text())
 ```
 
 **Guards**:
-- **ALWAYS include the User-Agent header** on every curl request — many government sites (agri.nv.gov, dot.nv.gov, etc.) return bot-check HTML instead of the PDF without it. This is not a retry step; it is the default.
+- **ALWAYS include the User-Agent header** on every curl request — this is the default, not a retry step
 - Check `Content-Length` header first. Skip if > 10MB (flag for manual review)
 - For PDFs > 50 pages, extract first 20 pages only (add `if page.number < 20` guard)
-- If curl still gets a 403 after User-Agent: try downloading to a temp file with `curl -sL -o /tmp/doc.pdf -H "User-Agent: ..." "URL"` then `python3 -c "import fitz; doc = fitz.open('/tmp/doc.pdf'); ..."`. If still blocked, use Playwright as final fallback.
+- If curl gets a 403 even with User-Agent: try downloading to temp file first, then
+  process. If still blocked, use Playwright as final fallback.
 - If PDF is password-protected or encrypted: flag and skip
+- **CRITICAL**: After curl, verify the content is actually a PDF (check first bytes).
+  If you get HTML instead, the bot protection intercepted you — retry with Playwright.
 - **CRITICAL**: After curl, verify the downloaded content is actually a PDF (check `file` output or first bytes). If you get HTML instead of a PDF, the bot-check blocked you — retry with the temp file approach or Playwright.
 
 ### Login-Gated Pages (~5%)
@@ -83,13 +108,11 @@ content and fetch them individually:
 - **Level 2**: If a Level 1 page references sub-pages with eligibility/amounts, fetch those
 - **MAX 2 levels**. Flag deeper content for manual review.
 
-### Fallback Chain (All Modes)
+### Fallback Summary
 
-When the primary method fails, try in order — never silently skip:
-```
-WebFetch → Playwright (headless) → FLAG for manual review
-```
-Always log what failed and why in your report.
+The detection-based routing above IS the fallback chain. The agent reads the
+rejection signal and routes to the right method. Never silently skip a URL —
+always FLAG if all methods fail, and log what you tried in your report.
 
 ---
 
@@ -419,7 +442,10 @@ The complete schema for the `extraction_data` JSONB column:
   "status": "open",
   "isNational": false,
   "disbursementType": "reimbursement",
-  "awardProcess": "competitive"
+  "awardProcess": "competitive",
+  "applicationWindowType": "dated",
+  "fundingStatus": "verified_active",
+  "fundingNote": "Page shows Apply Now with FY2026 dates as of 4/13/2026"
 }
 ```
 
@@ -431,6 +457,9 @@ These must always be populated (never null):
 - `categories`, `tags`
 - `status`, `isNational`, `matchingRequired`
 - `url`
+- `applicationWindowType` — one of: `dated`, `rolling`, `cycle_based`
+- `fundingStatus` — one of: `verified_active`, `presumed_active`, `limited_funding`, `oversubscribed`, `exhausted`
+- `fundingNote` — max 150 chars, evidence for the funding status assessment
 
 ### Optional Fields
 
@@ -439,6 +468,23 @@ These may be null if not found on the page:
 - `openDate`, `closeDate`
 - `eligibleLocations`, `matchingPercentage`
 - `disbursementType`, `awardProcess`
+
+### Application Window Type Guide
+
+- `dated` — program has specific open and close dates (e.g., "Jan 15 - Mar 31, 2026")
+- `rolling` — perpetual, no application window, first-come-first-served or year-round
+- `cycle_based` — has recurring cycles (annual, biennial) but specific dates may not be on this page
+
+### Funding Status Guide
+
+Assess from the page content. This is REQUIRED — do not skip:
+- `verified_active` — explicit "Apply Now" with current dates, live portal
+- `presumed_active` — page looks normal, no red flags (default if unsure)
+- `limited_funding` — mentions specific $ pool with first-come-first-served language
+- `oversubscribed` — waitlist, "limited availability", paused, high demand
+- `exhausted` — definitively "all funds awarded" or "program closed"
+
+`fundingNote` must contain your evidence in ≤150 chars.
 
 The `funding_source` object is always populated (from the source JOIN data at minimum).
 

--- a/.claude/skills/opportunity-discovery/SKILL.md
+++ b/.claude/skills/opportunity-discovery/SKILL.md
@@ -2,9 +2,10 @@
 name: opportunity-discovery
 description: >
   Phase 3 of the manual funding pipeline. Crawls program URLs to check
-  for open or upcoming application windows. Creates staging records for
-  opportunities found and updates smart scheduling on funding_programs.
-  Designed to be run by Agent Team teammates or standalone via Task tool.
+  for open or upcoming application windows. REPORTS findings to the
+  orchestrator (single-writer pattern — checkers do NOT write to the
+  database). The orchestrator validates and creates staging records.
+  Designed to be run by Agent Team teammates.
 ---
 
 # Opportunity Discovery — Phase 3
@@ -14,10 +15,22 @@ description: >
 Read this entire skill file before doing any work. Understand:
 1. **The Decision Tree** (Section 4) — it determines every action you take
 2. **Content Retrieval Standard** (Section 0a) — how to fetch pages and PDFs
-3. **SQL Templates** (Section 5) — exact INSERT/UPDATE patterns
+3. **Funding Status Assessment** (Section 3g) — REQUIRED for every program
+4. **Report Format** (Section 7) — what the orchestrator needs from you
 
 Unlike Phase 2, you do NOT need to read the taxonomy file. Phase 3 does not
 assign categories or activities — those already exist on the program from Phase 2.
+
+## CRITICAL: DO NOT WRITE TO THE DATABASE
+
+You are a **reporter**, not a writer. Your job is to crawl program URLs, assess
+application status, assess funding status, and report findings to the orchestrator
+via SendMessage. The orchestrator validates and creates staging records.
+
+- **DO NOT** run INSERT statements against `manual_funding_opportunities_staging`
+- **DO NOT** run UPDATE statements on `funding_programs` scheduling fields
+- **DO** use `mcp__postgres__query` for READ-ONLY queries (pre-flight, URL lookups)
+- **DO** send your complete findings to the team lead via SendMessage
 
 ---
 
@@ -25,24 +38,41 @@ assign categories or activities — those already exist on the program from Phas
 
 Use this decision tree for ALL URL fetching.
 
-### HTML Pages (~70% of URLs)
+### HTML Pages — Detection-Based Routing
 
 ```
-1. WebFetch(url)
-   → If content looks complete (has program details, not just nav/headers) → DONE
-2. If WebFetch returns empty/minimal/garbled content (JS-rendered page):
-   → Playwright: mcp__playwright__browser_navigate(url) + browser_snapshot()
-3. If Playwright also fails:
-   → FLAG as "JS-rendered, could not extract" — never silently skip
+1. Try WebFetch(url)
+
+2. Read the response. Route based on what you see:
+
+   a) Content looks complete (body text > 500 chars, has program details)
+      → DONE. Use this content.
+
+   b) HTTP 403, or response contains "Access Denied" / "edgesuite" / "Akamai"
+      → Akamai bot protection. Try:
+        curl -sL -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
+             AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+             -H "Accept: text/html" -H "Accept-Language: en-US,en" --compressed "URL"
+        If curl also returns 403 → use Playwright:
+          mcp__playwright__browser_navigate(url) + browser_snapshot()
+
+   c) Response is small (< 500 chars body) with <script> tags referencing
+      CMS frameworks ("civicplus", "requirejs", "vision-cms", "granicus")
+      → JS-rendered CMS. Try curl with User-Agent header (same as above).
+        If curl returns same thin content → use Playwright.
+
+   d) Response contains "Just a moment" / "Checking your browser" / "cf-"
+      → Cloudflare challenge. Skip curl, go directly to Playwright.
+
+   e) curl with headers also returns 403 AND Playwright also fails
+      → FLAG as unreachable. Never silently skip.
 ```
 
-### PDF Documents (~10% of URLs)
+### PDF Documents
 
-**Do NOT use WebFetch for PDFs** — it returns garbled binary.
+**Never use WebFetch for PDFs.** Always use curl piped to PyMuPDF:
 
 ```bash
-# Pipe directly — zero temp files
-# ALWAYS include User-Agent header (many gov sites block bare curl)
 curl -sL -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" "PDF_URL" | python3 -c "
 import sys, fitz
 doc = fitz.open(stream=sys.stdin.buffer.read(), filetype='pdf')
@@ -50,34 +80,19 @@ for page in doc: print(page.get_text())
 "
 ```
 
-**Guards**:
-- **ALWAYS include the User-Agent header** on every curl request — many government sites (agri.nv.gov, dot.nv.gov, etc.) return bot-check HTML instead of the PDF without it. This is not a retry step; it is the default.
-- Check `Content-Length` header first. Skip if > 10MB (flag for manual review)
-- For PDFs > 50 pages, extract first 20 pages only (add `if page.number < 20` guard)
-- If curl still gets a 403 after User-Agent: try downloading to a temp file with `curl -sL -o /tmp/doc.pdf -H "User-Agent: ..." "URL"` then `python3 -c "import fitz; doc = fitz.open('/tmp/doc.pdf'); ..."`. If still blocked, use Playwright as final fallback.
-- If PDF is password-protected or encrypted: flag and skip
-- **CRITICAL**: After curl, verify the downloaded content is actually a PDF (check `file` output or first bytes). If you get HTML instead of a PDF, the bot-check blocked you — retry with the temp file approach or Playwright.
+**Guards**: Always include User-Agent. Skip > 10MB. First 20 pages for > 50 page PDFs.
+If 403 even with UA, try temp file download then process. Verify output is PDF not HTML.
 
-### Login-Gated Pages (~5%)
+### Login-Gated Pages
 
-Flag as "Requires login, could not crawl" — skip entirely. Do not guess content.
+Flag as "Requires login, could not crawl" — skip entirely.
 
 ### Crawling Depth
 
-Each "level" is a separate WebFetch call. Agents must identify links in returned
-content and fetch them individually:
 - **Level 0**: Fetch the program URL from `program_urls`
-- **Level 1**: Follow links containing "Apply", "Application", "NOFA", "RFP", "Guidelines"
-- **Level 2**: If a Level 1 page references sub-pages with dates/deadlines, fetch those
+- **Level 1**: Follow "Apply", "Application", "NOFA", "RFP", "Guidelines" links
+- **Level 2**: Sub-pages with dates/deadlines
 - **MAX 2 levels**. Flag deeper content for manual review.
-
-### Fallback Chain (All Modes)
-
-When the primary method fails, try in order — never silently skip:
-```
-WebFetch → Playwright (headless) → FLAG for manual review
-```
-Always log what failed and why in your report.
 
 ---
 
@@ -268,7 +283,76 @@ Look for:
 - Press releases about new funding rounds
 - Third-party sites reporting on open opportunities
 
-### Step 3f — URL Failure Cascade
+### Step 3f — Funding Status Assessment (REQUIRED)
+
+For EVERY program you check — whether Open, Upcoming, or Nothing — you MUST assess
+the funding status. This is not optional. The orchestrator needs this to set the
+`funding_status` and `funding_note` fields on the opportunity.
+
+**Scan the page for these signals:**
+
+**VERIFIED_ACTIVE** — explicit evidence the program is currently funded and accepting:
+- "Apply Now" / "Submit Application" buttons with current-year dates
+- "Applications are being accepted" with current fiscal year reference
+- Active application portal (Formstack, ZoomGrants, eCivis) that loads
+- Recently posted NOFA/RFP with current dates
+
+**PRESUMED_ACTIVE** — default when nothing concerning is found:
+- Program is listed on the source's catalog/grants page
+- No closure, exhaustion, or waitlist language found
+- Page hasn't been updated recently but nothing says "closed"
+
+**LIMITED_FUNDING** — known finite pool that could exhaust:
+- Mentions a specific dollar pool ("$1.8M WIFA grant", "$5M program")
+- "First-come, first-served" / "until funds are exhausted"
+- "Limited funding available" / "subject to availability"
+
+**OVERSUBSCRIBED** — demand signals suggest funding is tight:
+- "Waitlist" / "applications processed as funding allows"
+- "Not accepting new applications at this time" (without permanent closure)
+- "Program is currently paused" / "check back for next cycle"
+- "High demand" / "oversubscribed" language
+
+**EXHAUSTED** — ONLY set when DEFINITIVE (do not speculate):
+- "All funds awarded for this cycle"
+- "Program closed" / "no longer accepting applications"
+- "Funding has been fully allocated"
+- Application portal explicitly disabled with closure message
+
+**Your report MUST include for each program:**
+```
+  funding_status: verified_active / presumed_active / limited_funding / oversubscribed / exhausted
+  funding_note: "[one sentence, max 150 chars, with evidence from the page]"
+```
+
+If you cannot determine the funding status because the page was unreachable,
+say: `funding_status: presumed_active` / `funding_note: "Page unreachable — status unverified"`
+
+### Step 3f-2 — Application Window Type Assessment (REQUIRED)
+
+Also assess the application window type for each program:
+
+**DATED** — has specific open and close dates:
+- "Applications open January 15, close March 31"
+- A published NOFA with explicit deadline
+
+**ROLLING** — perpetual, no application window:
+- "Applications accepted on a rolling basis"
+- "Open until funds are exhausted"
+- "Apply anytime" / no deadline mentioned anywhere
+- Rebate programs with no cycle (first-come-first-served)
+
+**CYCLE_BASED** — has known recurring cycles but specific dates may not be captured:
+- "Annual application cycle" / "FY2027 round expected fall 2026"
+- "Applications typically open in October"
+- Program has a history of annual/biennial rounds
+
+**Your report MUST include:**
+```
+  window_type: dated / rolling / cycle_based
+```
+
+### Step 3g — URL Failure Cascade
 
 If a program URL returns 404, timeout, or unusable content:
 
@@ -354,106 +438,94 @@ When `next_check_at` arrives for a Row 3 program (upcoming with date):
 
 ---
 
-## 5. SQL Templates
+## 5. Report Format (What the Orchestrator Needs)
 
-### INSERT Staging Record
+Since you are a reporter (not a writer), your output is a structured report
+sent via SendMessage to the team lead. The orchestrator uses this to write
+staging records and update program scheduling.
 
-```sql
--- Run via psql
-INSERT INTO manual_funding_opportunities_staging (
-  id,
-  program_id,
-  source_id,
-  title,
-  url,
-  program_urls,
-  content_type,
-  discovery_method,
-  discovered_by,
-  extraction_status,
-  analysis_status,
-  storage_status
-) VALUES (
-  gen_random_uuid(),
-  'PROGRAM_UUID',
-  'SOURCE_UUID',
-  'OPPORTUNITY_TITLE',
-  'PRIMARY_APPLICATION_URL',
-  'PROGRAM_URLS_JSONB'::JSONB,
-  'opportunity',
-  'phase3_crawl',
-  'opportunity-discovery-agent',
-  'pending',
-  'pending',
-  'pending'
-);
+### Per-Program Report Fields (ALL REQUIRED)
+
+```
+PROGRAM: [Program Name]
+  program_id: [UUID]
+  source_id: [UUID]
+  source_name: [Name]
+
+  status: Open / Upcoming / Nothing
+  window_type: dated / rolling / cycle_based
+  open_date: [YYYY-MM-DD or null]
+  close_date: [YYYY-MM-DD or null]
+  application_url: [URL of the actual apply page, if different from program page]
+
+  funding_status: verified_active / presumed_active / limited_funding / oversubscribed / exhausted
+  funding_note: "[max 150 chars — evidence from the page for your funding_status call]"
+
+  has_details: true / false  (does the page have substantive program details or just an announcement?)
+  guidelines_url: [URL of NOFA/RFP/guidelines PDF, if found]
+
+  suggested_next_check: [YYYY-MM-DD]
+  next_check_reason: "[why this date]"
+
+  new_urls_found: [list of any new URLs discovered that should be added to program_urls]
+  flags: [any concerns, unreachable URLs, stale content, etc.]
 ```
 
-**Field notes**:
-- `title`: Use format "[Program Name] - [Year/Round]" if round info available,
-  otherwise just the program name
-- `url`: The most specific application-related URL found (application page > program page)
-- `program_urls`: Copy of `funding_programs.program_urls` at discovery time — carry
-  through pipeline so downstream agents have URL context
-- `content_type`: Always `'opportunity'` for Phase 3 records
-- `discovery_method`: Always `'phase3_crawl'`
-- All status fields start as `'pending'` — Phase 4/5/6 will process them
-- **No ON CONFLICT** — staging is a pure processing inbox. Each check round creates
-  a new record. Smart scheduling prevents duplicate checks for the same window.
+### Suggested Recheck Schedule (for `suggested_next_check`)
 
-### UPDATE Program Scheduling
+| Situation | Suggested Date | Reason |
+|---|---|---|
+| Open, dated (has close date) | close_date | Check for next round after this one closes |
+| Open, rolling | NOW + 90 days | Recheck funding status periodically |
+| Upcoming, details available | open_date - 7 days | Final confirmation before it opens |
+| Upcoming, NO details yet | NOW + 30 days | Monthly check until NOFA/details published |
+| Cycle-based, know typical month | typical_month - 60 days | Check 2 months early for NOFA |
+| Nothing found | NOW + 30 days | Try again next month |
+| All URLs failed | NULL (mark inactive) | Stop checking until manually re-enabled |
 
-```sql
--- Run via psql
-UPDATE funding_programs
-SET last_checked_at = NOW(),
-    next_check_at = 'CALCULATED_DATE'::TIMESTAMPTZ
-WHERE id = 'PROGRAM_UUID';
-```
+**Key principle for upcoming programs:** We want the details as early as possible,
+not just before the window opens. If we discover in January that a program opens
+in August but has no NOFA yet, check monthly until the NOFA appears. Once the NOFA
+is published, stage it immediately — don't wait until August.
 
-Replace `CALCULATED_DATE` per the Decision Tree (Section 4):
-- Row 1: The opportunity's close date
-- Row 2: `NOW() + INTERVAL '180 days'`
-- Row 3: The opportunity's open date minus 30 days
-- Row 4-6: `NOW() + INTERVAL '30 days'`
+### What the Orchestrator Does With Your Report
 
-### UPDATE Program URLs (When New URL Found)
-
-```sql
--- Run via psql
-UPDATE funding_programs
-SET program_urls = program_urls || '[{"url": "NEW_URL", "type": "application", "notes": "Found by Phase 3 crawl"}]'::JSONB
-WHERE id = 'PROGRAM_UUID';
-```
-
-### Mark Program Inactive (All URLs Failed)
-
-```sql
--- Run via psql
-UPDATE funding_programs
-SET status = 'inactive',
-    last_checked_at = NOW(),
-    next_check_at = NULL
-WHERE id = 'PROGRAM_UUID';
-```
+The orchestrator (not you) will:
+1. **Dedup check**: Does a staging record or funding_opportunity already exist for this program_id?
+   - If a rolling opportunity already exists with the same source_hash → skip (just update verified_at)
+   - If dated and the dates are different → new round, create staging record
+2. **INSERT staging record** with your reported fields + the new funding status fields
+3. **UPDATE program scheduling** (last_checked_at, next_check_at)
+4. **Log** to claude_change_log
 
 ---
 
 ## 6. Program Scheduling Updates
 
-EVERY program checked gets scheduling updates, regardless of outcome:
+The orchestrator handles scheduling updates based on your report. Include your
+`suggested_next_check` and `next_check_reason` in every per-program report.
 
-| Outcome | `last_checked_at` | `next_check_at` |
-|---------|-------------------|-----------------|
-| Open, has close date | `NOW()` | `close_date` |
-| Open, perpetual | `NOW()` | `NOW() + 180 days` |
-| Upcoming, with date | `NOW()` | `open_date - 30 days` |
-| Upcoming, no date | `NOW()` | `NOW() + 30 days` |
-| Nothing found | `NOW()` | `NOW() + 30 days` |
-| All URLs failed | `NOW()` | `NULL` (inactive) |
+Reference table for suggested dates:
 
-**Always update `last_checked_at`** — even for skipped programs. This provides
-an audit trail of when each program was last reviewed.
+| Outcome | Suggested `next_check_at` | Reason |
+|---------|---------------------------|--------|
+| Open, dated (has close date) | `close_date` | Check for next round after this one closes |
+| Open, rolling | `NOW() + 90 days` | Periodic funding status recheck |
+| Upcoming, details available | `open_date - 7 days` | Final confirmation before window opens |
+| Upcoming, NO details yet | `NOW() + 30 days` | Monthly check until NOFA/details published |
+| Cycle-based, know typical month | `typical_month - 60 days` | Early check for NOFA publication |
+| Nothing found | `NOW() + 30 days` | Try again next month |
+| All URLs failed | `NULL` (mark inactive) | Stop checking |
+
+**Key principle:** We want opportunity details as early as possible. If we learn
+in January that a program opens in August but has no NOFA yet, suggest monthly
+rechecks (not a single check 7 days before August). Once the NOFA is published,
+the orchestrator stages it immediately.
+
+**For rolling programs:** The orchestrator will check whether a funding_opportunity
+already exists for this program_id before creating a new staging record. If one
+exists with the same source_hash, it just updates `funding_verified_at` without
+re-staging.
 
 ---
 

--- a/.claude/skills/pipeline-orchestrator/SKILL.md
+++ b/.claude/skills/pipeline-orchestrator/SKILL.md
@@ -20,6 +20,28 @@ don't have APIs — utilities, county governments, state agencies, foundations.
 **Goal**: Find EVERY relevant opportunity with complete specs. Thoroughness is
 non-negotiable — a missed source means missed opportunities for our sales team.
 
+**Business context**: Meridian is a GC/ESCO (general contractor / energy services
+company). Our clients are commercial entities: municipalities, school districts,
+hospitals, businesses, government agencies. We find funding that lets these clients
+hire us for construction and installation projects.
+
+### Model Selection Rule
+
+**All spawned agents MUST use `model: "sonnet"` EXCEPT the analysis-agent.**
+
+| Agent Type | Model | Why |
+|---|---|---|
+| source-registry-agent | **sonnet** | Web search + propose — doesn't need deep reasoning |
+| program-discovery-agent | **sonnet** | URL crawl + extract — pattern matching, not analysis |
+| opportunity-discovery-agent | **sonnet** | Status check + staging insert — straightforward |
+| extraction-agent | **sonnet** | Field mapping from page content — structured work |
+| **analysis-agent** | **opus** | Content enhancement + scoring adjustment needs deep reasoning |
+| storage-agent | **sonnet** | Data sanitization + UPSERT — mechanical |
+
+Include `model: "sonnet"` (or `model: "opus"` for analysis) in every `Agent()` or
+`Task()` call. If omitted, the agent inherits the orchestrator's model (opus),
+which wastes tokens on work that doesn't need it.
+
 **Three-tier data model**: Sources → Programs → Opportunities
 - **Sources** = who funds things (utilities, agencies, foundations) → `funding_sources`
 - **Programs** = what they fund (persistent entities with URLs) → `funding_programs`
@@ -303,9 +325,14 @@ parallel and validate each other's findings — this is how we ensure thoroughne
 > "Am I about to call `TeamCreate`? If not, STOP. I must use TeamCreate."
 > If I'm about to call `Task(subagent_type=...)` without a `team_name`, I am doing it wrong.
 
-### Concrete Tool Call Pattern
+### Concrete Tool Call Pattern — Single-Writer (Orchestrator Writes)
 
-Here is the EXACT sequence of tool calls for spawning a discovery team.
+**CRITICAL: Teammates are PROPOSERS, not writers.** Teammates search the web and
+propose entities via SendMessage to the orchestrator. The orchestrator validates,
+deduplicates, and performs all database writes. This ensures zero bad data enters
+the database.
+
+Here is the EXACT sequence of tool calls for spawning a Phase 1 discovery team.
 **Follow this pattern literally — do not improvise an alternative.**
 
 ```
@@ -316,79 +343,124 @@ TeamCreate(
   description="Phase 1: Discover FL County + State funding sources"
 )
 
-STEP 2: Create shared tasks for the team
+STEP 2: Spawn ALL teammates IN PARALLEL (one message, all Task calls together)
 ─────────────────────────
-TaskCreate(subject="Search via regulatory strategies (2+3)", ...)
-TaskCreate(subject="Search via aggregator strategies (4+6)", ...)
-TaskCreate(subject="Search via direct strategies (1+5)", ...)
-TaskCreate(subject="Cross-check and deduplicate findings", ...)
-
-STEP 3: Spawn ALL teammates IN PARALLEL (one message, all Task calls together)
-─────────────────────────
+// IMPORTANT: model: "sonnet" for ALL Phase 1 teammates (not opus)
 // County pair:
 Task(
   subagent_type="source-registry-agent",
+  model="sonnet",
   team_name="source-discovery-FL",
   name="county-direct",
   prompt="You are the COUNTY-DIRECT teammate. Execute strategies 1+5+7.
-          State: FL, Funder type: County.
+          State: FL
+
+          ## SCOPE
+          You are searching for type='County' sources ONLY.
+          If you find an entity that should be a different type (Utility, Municipality,
+          State, etc.), DO NOT propose it. Note it in your report as 'out-of-scope
+          entity found: [name], suggested type: [X]' and the orchestrator will decide.
+          Also search for regional Councils of Governments (COGs) that administer
+          CDBG/HOME on behalf of small counties — propose these as type='Other'.
+
           Read SEARCH-REFERENCE.md for detailed instructions.
-          DB writes: source .env.local && psql \"$DEV_CLAUDE_URL\"
-          When done, broadcast your entity list to the team.
+
+          ## CRITICAL: DO NOT WRITE TO THE DATABASE
+          You are a PROPOSER, not a writer. Search, verify, and propose entities.
+          Send your proposed entity list to team-lead via SendMessage.
+          The orchestrator will validate and INSERT.
+
+          When done, broadcast your entity list to the team for cross-checking.
           Cross-check with county-aggregator's findings."
 )
 
 Task(
   subagent_type="source-registry-agent",
+  model="sonnet",
   team_name="source-discovery-FL",
   name="county-aggregator",
   prompt="You are the COUNTY-AGGREGATOR teammate. Execute strategy 4.
-          State: FL, Funder type: County.
-          Read SEARCH-REFERENCE.md for detailed instructions.
-          DB writes: source .env.local && psql \"$DEV_CLAUDE_URL\"
-          When done, broadcast your entity list to the team.
+          State: FL
+
+          ## SCOPE
+          You are searching for type='County' sources ONLY.
+          [same scope block as above]
+
+          ## CRITICAL: DO NOT WRITE TO THE DATABASE
+          [same no-write block as above]
+
           Cross-check with county-direct's findings."
 )
 
-// State pair:
+// State pair (same pattern with type='State' in SCOPE block):
 Task(
   subagent_type="source-registry-agent",
+  model="sonnet",
   team_name="source-discovery-FL",
   name="state-direct",
-  prompt="You are the STATE-DIRECT teammate. Execute strategies 5+7.
-          State: FL, Funder type: State.
-          Read SEARCH-REFERENCE.md for detailed instructions.
-          DB writes: source .env.local && psql \"$DEV_CLAUDE_URL\"
-          When done, broadcast your entity list to the team.
-          Cross-check with state-aggregator's findings."
+  prompt="... [same pattern, SCOPE says type='State' ONLY] ..."
 )
 
 Task(
   subagent_type="source-registry-agent",
+  model="sonnet",
   team_name="source-discovery-FL",
   name="state-aggregator",
-  prompt="You are the STATE-AGGREGATOR teammate. Execute strategy 4.
-          State: FL, Funder type: State.
-          Read SEARCH-REFERENCE.md for detailed instructions.
-          DB writes: source .env.local && psql \"$DEV_CLAUDE_URL\"
-          When done, broadcast your entity list to the team.
-          Cross-check with state-direct's findings."
+  prompt="... [same pattern, SCOPE says type='State' ONLY] ..."
 )
 
-STEP 4: Wait for teammates to complete and cross-check
+STEP 3: Wait for teammates to search and cross-check
 ─────────────────────────
 Teammates will:
-  a) Execute their assigned strategies
-  b) Broadcast their entity list to the team via SendMessage
-  c) Cross-check other teammates' lists
-  d) Converge on a master deduplicated list
+  a) Execute their assigned search strategies (the slow part — 10-15 min)
+  b) Broadcast their proposed entity list to the team via SendMessage
+  c) Cross-check other teammates' proposals (flag overlaps, stale entities, type issues)
+  d) Send FINAL PROPOSED LIST to team-lead with confidence levels
 
-STEP 5: Collect results and clean up
+Each proposed entity includes:
+  - name (official name from the entity's own website)
+  - website URL
+  - type
+  - description
+  - proposed catalog URLs (for source_program_urls)
+  - confidence (HIGH/MEDIUM/LOW)
+  - name_source ("from footer", "from About Us page", "from breadcrumb", "from search result only")
+
+STEP 4: Orchestrator validates and writes (the fast part — 3-5 min)
 ─────────────────────────
-- Orchestrator collects the final validated entity list
-- Sends shutdown_request to all teammates
+For each proposed entity, the orchestrator:
+
+  a) DEDUP CHECK — by URL AND normalized name:
+     SELECT id, name, website FROM funding_sources
+     WHERE state_code = $1
+       AND (website ILIKE '%' || $domain || '%'
+            OR LOWER(name) ILIKE '%' || $normalized_name || '%')
+       AND name NOT LIKE '[DEPRECATED-%';
+     Also check source_program_urls for URL matches.
+
+  b) TYPE VALIDATION — does the proposed type match the run scope? If a teammate
+     proposed type='Utility' in a County-scoped run, the orchestrator flags it as
+     out-of-scope (log it, don't insert).
+
+  c) NAME SPOT-CHECK — for any entity where name_source is "from search result only"
+     (not verified against official website), do a quick WebFetch of the website URL
+     and check page title / breadcrumb / footer for the official name. Correct if needed.
+
+  d) INSERT — if passes all checks:
+     INSERT INTO funding_sources (name, website, type, sectors, state_code, pipeline, description)
+     VALUES (..., 'manual', ...);
+     INSERT INTO source_program_urls (source_id, url) VALUES (...);
+
+  e) LOG — write to claude_change_log:
+     INSERT INTO claude_change_log (table_name, operation, pipeline_phase, batch_id, record_count, change_reason)
+     VALUES ('funding_sources', 'INSERT', 'source_registry', $batch_id, 1, 'Registered: [name]');
+
+STEP 5: Clean up
+─────────────────────────
+- Send shutdown_request to all teammates
 - TeamDelete to clean up
-- Proceeds to next phase or reports summary
+- Report: "Phase 1 complete: X sources registered, Y catalog URLs, Z out-of-scope flagged"
+- Proceed to Phase 2
 ```
 
 ### Team Sizing Per Funder Type
@@ -470,10 +542,12 @@ county-aggregator's findings when county-direct had already shut down).
 ### Phase 1 — Source Registry Teams
 
 Follow the Concrete Tool Call Pattern above. Key points:
-- Each teammate gets `subagent_type="source-registry-agent"` (loads the source-registry skill)
+- Each teammate gets `subagent_type="source-registry-agent"`, `model="sonnet"`
 - Include strategy group name AND numbers in the prompt
-- Include state_code, type, database env var, and batch_id in the prompt
-- Teammates write to DB independently, then cross-check for completeness
+- Include state_code and the SCOPE block (what type IS in scope) in every prompt
+- **Teammates DO NOT write to DB** — they propose entities via SendMessage
+- **Orchestrator validates and writes** — dedup by URL+name, type validation, name spot-check
+- Include `## CRITICAL: DO NOT WRITE TO THE DATABASE` block in every teammate prompt
 
 ### Phase 2 — Program Discovery Teams (Two-Round Pattern)
 
@@ -690,17 +764,17 @@ Task(subagent_type="program-discovery-agent",
 ```
 Extractors are deterministic — they don't need cross-checking, so standalone mode is fine.
 
-### Phase 3 — Opportunity Discovery Teams
+### Phase 3 — Opportunity Discovery Teams (Single-Writer Pattern)
+
+**Checkers are REPORTERS, not writers.** They crawl URLs, assess status and funding,
+and send structured reports to the orchestrator. The orchestrator validates, deduplicates,
+and performs all database writes.
 
 Team name: `opportunity-check-[SCOPE]` (e.g., `opportunity-check-AZ-utility`)
 
 ```
-STEP 0: Pre-flight (orchestrator runs directly — NOT delegated to teammates)
+STEP 0: Pre-flight (orchestrator runs directly)
 ─────────────────────────
-// NOTE: Auto-close is handled by pg_cron daily job (update_opportunity_statuses())
-// running at 00:05 UTC. No manual auto-close needed here.
-// The view also has a calculated_status column for real-time display.
-
 // Smart scheduling query — get eligible programs
 mcp__postgres__query:
 SELECT fp.id, fp.name, fp.description, fp.program_urls,
@@ -722,68 +796,87 @@ WHERE fp.status IN ('active', 'unknown')
   )
 ORDER BY fp.source_id, fp.name;
 
-// Report: "Pre-flight: auto-closed X opportunities. Y programs eligible for checking."
-// If zero eligible, report and stop.
+// Report count and stop if zero eligible.
 
-STEP 1: Create team
+STEP 1: Create team + spawn checkers (model: "sonnet")
 ─────────────────────────
-TeamCreate(
-  team_name="opportunity-check-AZ-utility",
-  description="Phase 3: Check AZ utility programs for open/upcoming opportunities"
-)
+TeamCreate(team_name="opportunity-check-AZ-utility", ...)
 
-STEP 2: Spawn opportunity-discovery-agent teammates
-─────────────────────────
-// Group programs by source (~10-15 programs per teammate)
-// Each teammate gets all programs from one or more sources
-
+// Group programs by source (~10-15 per checker)
 Task(
   subagent_type="opportunity-discovery-agent",
+  model="sonnet",
   team_name="opportunity-check-AZ-utility",
   name="checker-aps",
-  prompt="You are an opportunity discovery teammate.
-          Read your skill file: .claude/skills/opportunity-discovery/SKILL.md
+  prompt="You are an opportunity discovery REPORTER (not a writer).
+          Read: .claude/skills/opportunity-discovery/SKILL.md
 
-          Your assigned programs (APS — Arizona Public Service):
-          1. Program Name (id: UUID, urls: [...])
-          2. Program Name (id: UUID, urls: [...])
-          ... (all APS programs from the query)
+          ## CRITICAL: DO NOT WRITE TO THE DATABASE
+          Report your findings via SendMessage. The orchestrator writes.
 
-          For each program:
-          - Crawl program_urls per Content Retrieval Standard
-          - Follow application links 1-2 levels deep
-          - Apply Decision Tree (Skill Section 4)
-          - INSERT staging records for Open/Upcoming findings
-          - UPDATE last_checked_at and next_check_at on each program
+          Your assigned programs: [list with IDs, URLs]
 
-          Database writes: psql \"$DEV_CLAUDE_URL\" -c \"...\"
-          Report results when done."
+          For each program, report ALL of these fields:
+            status, window_type, open_date, close_date, application_url,
+            funding_status, funding_note, has_details, guidelines_url,
+            suggested_next_check, next_check_reason, new_urls_found, flags
+
+          Send your complete report to team-lead when done."
 )
 
-Task(
-  subagent_type="opportunity-discovery-agent",
-  team_name="opportunity-check-AZ-utility",
-  name="checker-tep",
-  prompt="... (same pattern, TEP programs)"
-)
-
-// = 1 teammate per source (or per ~10-15 programs if source is very large)
-
-STEP 3: Collect results
+STEP 2: Collect checker reports
 ─────────────────────────
-Teammates will:
+Checkers will:
   a) Crawl each program's URLs
-  b) Determine Open/Upcoming/Nothing status
-  c) INSERT staging records for Open/Upcoming findings
-  d) UPDATE program scheduling (last_checked_at, next_check_at)
-  e) Report results to team lead
+  b) Assess application status (Open / Upcoming / Nothing)
+  c) Assess funding status (verified_active / presumed_active / limited_funding /
+     oversubscribed / exhausted)
+  d) Assess window type (dated / rolling / cycle_based)
+  e) Report ALL findings to team lead via SendMessage (NO DB writes)
+
+STEP 3: Orchestrator validates and writes (the critical step)
+─────────────────────────
+For each program in the checker reports, the orchestrator applies this logic:
+
+  === RULE: Open + exhausted should NEVER coexist on a stored opportunity ===
+
+  IF checker reports funding_status=exhausted:
+    → Check: does an Open opportunity exist for this program_id?
+    → IF YES: UPDATE it to status='Closed', funding_status='exhausted',
+      funding_note=[evidence], funding_verified_at=NOW()
+    → IF NO: do nothing (no staging record — money is gone)
+    → Set next_check_at = NOW() + 30 days (short cycle to catch refunding)
+    → Log: "Closed [title] due to funding exhaustion"
+    → Do NOT compare hashes — the page changed (exhaustion language appeared),
+      but we don't want to re-stage it, we want to close it.
+
+  IF checker reports status=Open AND funding_status != exhausted:
+    → Check: does an Open opportunity already exist for this program_id?
+    → IF YES AND window_type=rolling: compare source_hash.
+      - Hash UNCHANGED: just UPDATE funding_verified_at=NOW() and
+        funding_status=[checker's assessment]. No new staging record.
+      - Hash CHANGED: content was updated (new amounts, new eligibility, etc.)
+        — create a new staging record to re-extract the updated content.
+    → IF YES AND window_type=dated with different dates: new round — create staging record
+    → IF NO existing opportunity: create new staging record with all fields
+    → Set next_check_at per the scheduling table in opportunity-discovery SKILL.md
+
+  IF checker reports status=Upcoming:
+    → IF has_details=true: create staging record (capture the details early)
+    → IF has_details=false: do NOT create staging record, just set
+      next_check_at = NOW() + 30 days (check monthly until details appear)
+
+  IF checker reports status=Nothing:
+    → Do NOT create staging record
+    → Set next_check_at per checker's suggestion
+
+  For ALL programs: UPDATE funding_programs.last_checked_at = NOW()
+  For ALL programs: UPDATE funding_programs.next_check_at = [from report]
 
 STEP 4: Clean up and chain
 ─────────────────────────
-- Collect all teammate reports
-- Send shutdown_request to all teammates
-- TeamDelete to clean up
-- Report: "Phase 3 complete: X open, Y upcoming, Z skipped across N programs"
+- Shutdown all checkers, TeamDelete
+- Report: "Phase 3 complete: X staged, Y closed-exhausted, Z unchanged, W nothing-found"
 - If auto-chaining to Phase 4: check staging counts and proceed
 ```
 

--- a/.claude/skills/program-discovery/SKILL.md
+++ b/.claude/skills/program-discovery/SKILL.md
@@ -29,24 +29,47 @@ If unsure about a value, map to the closest taxonomy match. Never fabricate cate
 
 Use this decision tree for ALL URL fetching in both scout and extractor modes.
 
-### HTML Pages (~70% of URLs)
+### HTML Pages — Detection-Based Routing
 
 ```
-1. WebFetch(url)
-   → If content looks complete (has program details, not just nav/headers) → DONE
-2. If WebFetch returns empty/minimal/garbled content (JS-rendered page):
-   → Playwright: mcp__playwright__browser_navigate(url) + browser_snapshot()
-3. If Playwright also fails:
-   → FLAG as "JS-rendered, could not extract" — never silently skip
+1. Try WebFetch(url)
+
+2. Read the response. Route based on what you see:
+
+   a) Content looks complete (body text > 500 chars, has program details)
+      → DONE. Use this content.
+
+   b) HTTP 403, or response contains "Access Denied" / "edgesuite" / "Akamai"
+      → Akamai bot protection. Try:
+        curl -sL -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)
+             AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+             -H "Accept: text/html" -H "Accept-Language: en-US,en" --compressed "URL"
+        If curl also returns 403 → use Playwright:
+          mcp__playwright__browser_navigate(url) + browser_snapshot()
+
+   c) Response is small (< 500 chars body) with <script> tags referencing
+      CMS frameworks ("civicplus", "requirejs", "vision-cms", "granicus")
+      → JS-rendered CMS. Try curl with User-Agent header (same as above).
+        If curl returns same thin content → use Playwright.
+
+   d) Response contains "Just a moment" / "Checking your browser" / "cf-"
+      → Cloudflare challenge. Skip curl, go directly to Playwright.
+
+   e) curl with headers also returns 403 AND Playwright also fails
+      → FLAG as unreachable: "Content retrieval failed after WebFetch +
+        curl + Playwright. Needs manual review." Never silently skip.
 ```
 
-### PDF Documents (~10% of URLs)
+No per-site lookup tables needed. The agent reads the rejection signal and adapts.
 
-**Do NOT use WebFetch for PDFs** — it returns garbled binary.
+### PDF Documents
+
+**Never use WebFetch for PDFs** — it returns garbled binary. Always use curl piped
+to PyMuPDF:
 
 ```bash
-# Pipe directly — zero temp files
-curl -sL "PDF_URL" | python3 -c "
+# Always include User-Agent header — many gov sites block bare curl
+curl -sL -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" "PDF_URL" | python3 -c "
 import sys, fitz
 doc = fitz.open(stream=sys.stdin.buffer.read(), filetype='pdf')
 for page in doc: print(page.get_text())
@@ -56,29 +79,29 @@ for page in doc: print(page.get_text())
 **Guards**:
 - Check `Content-Length` header first. Skip if > 10MB (flag for manual review)
 - For PDFs > 50 pages, extract first 20 pages only (add `if page.number < 20` guard)
-- If curl gets a 403: retry with `curl -sL -H "User-Agent: Mozilla/5.0" "URL"`
+- If curl gets a 403 even with User-Agent: try downloading to temp file first, then
+  process. If still blocked, use Playwright to navigate to the PDF URL (some sites
+  serve PDFs through their bot-protection layer).
 - If PDF is password-protected or encrypted: flag and skip
+- **CRITICAL**: After curl, verify the content is actually a PDF (check first bytes).
+  If you get HTML instead, the bot protection intercepted you — retry with Playwright.
 
-### Login-Gated Pages (~5%)
+### Login-Gated Pages
 
 Flag as "Requires login, could not crawl" — skip entirely. Do not guess content.
 
 ### Crawling Depth (Scouts)
 
-Each "level" is a separate WebFetch call. Agents must identify links in returned
-content and fetch them individually:
+Each "level" is a separate fetch call (using the routing above). Agents must
+identify links in returned content and fetch them individually:
 - **Level 0**: Fetch the assigned catalog URL
-- **Level 1**: Parse content for program links, WebFetch each one
-- **Level 2**: If a Level 1 page references sub-pages, fetch those too
+- **Level 1**: Parse content for program links, fetch each one
+- **Level 2**: If a Level 1 page references sub-pages with eligibility/amounts, fetch those
 - **MAX 2 levels**. Flag deeper content for manual review.
 
-### Fallback Chain (All Modes)
-
-When the primary method fails, try in order — never silently skip:
-```
-WebFetch → Playwright (headless) → FLAG for manual review
-```
-Always log what failed and why in your report.
+**Note for County/Municipality sources:** Government CMS sites often use navigation
+hubs as catalog landing pages. Real program content is frequently 2 clicks deep.
+Always attempt Level 2 for these source types.
 
 ---
 
@@ -105,6 +128,50 @@ spawns extractors with deduplicated program assignments.
 - Scout mode: list of discovered programs with URLs, types, and confidence levels
 - Extractor mode: programs written to `funding_programs` table with all fields populated
 - Summary report: counts of new, updated, skipped programs and any flags
+
+### Program Granularity Rule
+
+When a single program page lists multiple sub-rebates or sub-grants under one
+umbrella (e.g., a "Home Weatherization" page with 7 different rebate types at
+different dollar amounts), register as **ONE program record**. Capture the
+sub-types in the `description` and `eligible_project_types` array.
+
+Only split into separate records when sub-programs have:
+- Independent application processes (different forms, different portals)
+- Different eligibility requirements (different applicant types)
+- Different funding sources (one is CDBG, another is General Fund)
+
+If they share one application, one eligibility set, and one funding source,
+they are one program with multiple components.
+
+### Cross-Source Attribution Rule
+
+When a catalog page lists a program that is administered by a **different entity**
+than the source being scouted:
+
+1. Check who actually administers the program — look for "administered by",
+   contact info, application portal domain
+2. If administered by the catalog owner → register normally
+3. If administered by a different entity → **DO NOT register** under the
+   catalog owner. Note it in your report: "Cross-listed program found:
+   [program name], actual administrator: [entity name]"
+4. The orchestrator will find that program when the correct source is scouted
+
+**Signs a program belongs to someone else:**
+- Program URL is on a different domain than the source's website
+- Contact email uses a different organization's domain
+- Page text says "administered by [other entity]" or "funded by [other entity]"
+- The page is clearly a referral/directory listing, not a program detail page
+
+### Business Context
+
+Meridian is a GC/ESCO (general contractor / energy services company). Our clients
+are **commercial entities**: municipalities, school districts, hospitals, businesses,
+government agencies. We find funding that lets these clients hire us for
+construction and installation projects. Programs that only serve individual
+homeowners or residents are NOT relevant to our business — they should still be
+discovered (for completeness) but will be filtered out by the 3-gate system in
+the extractor.
 
 ---
 

--- a/.claude/skills/source-registry/SEARCH-REFERENCE.md
+++ b/.claude/skills/source-registry/SEARCH-REFERENCE.md
@@ -62,6 +62,9 @@ each source maps to one department's programs.
 - Search: `"[County Name] county government departments"`, `"[County Name] county grants programs"`
 - Navigate to the county government website → find the department directory
 - Identify departments that administer funding programs (not just regulatory ones)
+- **IMPORTANT: Verify it's a funder, not just a regulator.** Look for "Apply", "Grant
+  Application", "Funding Opportunity", "RFP", "NOFA" on the department's pages. If NONE
+  of these terms appear, the department is likely regulatory-only — do NOT propose it.
 
 **Step 2 — For each taxonomy category, search for the responsible department:**
 - `"[County Name] county sustainability department"` → Sustainability/Environment dept
@@ -77,6 +80,37 @@ each source maps to one department's programs.
 - Website: the department's specific page/section, not the county homepage
 - Sectors: only the taxonomy categories relevant to that department
 - Description: what programs this department administers
+
+### For Councils of Governments (COGs) — Register as type='Other'
+
+**What COGs are:** Regional intergovernmental partnerships of cities, towns, and counties.
+They act as the middleman between federal/state government and small local governments
+that are too small to receive HUD CDBG/HOME funding directly ("non-entitlement communities").
+
+**Why they matter:** In most states, the majority of rural counties and small cities get
+their CDBG/HOME money through a COG, not directly from HUD. The COG decides which projects
+get funded and awards the grants. If you only register county departments, you miss the
+actual decision-maker for rural areas.
+
+**How to find them:**
+- Search: `"[State] council of governments"`, `"[State] regional planning organizations"`
+- Search: `"[State] CDBG non-entitlement" council of governments`
+- Check: National Association of Regional Councils (NARC) member directory
+- Check: HUD's list of state CDBG program contacts → they often list the COGs
+- Each state typically has 3-15 COGs covering different geographic regions
+
+**When searching for County type, ALSO search for COGs in the same state.**
+Propose them as `type='Other'` with a description noting:
+- Which counties/cities they serve
+- What federal pass-through programs they administer (CDBG, HOME, WIOA, etc.)
+- Their official website
+
+**Example COGs (Arizona):**
+- NACOG — Northern Arizona Council of Governments (Apache, Coconino, Navajo, Yavapai)
+- CAG — Central Arizona Governments (Gila, Pinal)
+- SEAGO — Southeastern Arizona Governments Organization (Cochise, Graham, Greenlee, Santa Cruz)
+- WACOG — Western Arizona Council of Governments (La Paz, Mohave, Yuma)
+- MAG — Maricopa Association of Governments (Maricopa County metro area)
 
 **Common department types that run programs:**
 | Department | Typical Programs | Taxonomy Categories |
@@ -219,9 +253,41 @@ Phase 2 (Program Discovery) will determine which have active programs.
 2. ACEEE tracks which utilities run energy efficiency programs and ranks states
 3. Their state scorecards list the major utilities running EE programs
 
+### Aggregator Strengths and Weaknesses by Funder Type
+
+**IMPORTANT:** DSIRE, ACEEE, and EnergySage are built around utility and state-level
+energy policy. They have **thin coverage of county and municipal programs** in most states.
+Do NOT rely on them as primary sources for County or Municipality funder types.
+
+| Funder Type | Best Aggregator Sources (priority order) | Notes |
+|-------------|----------------------------------------|-------|
+| **Utility** | DSIRE (primary), EIA/PUC (validation), ACEEE, EnergySage | Strong coverage — DSIRE is comprehensive for utility incentives |
+| **State** | DSIRE (Implementing Sector=State), state energy office sites | Good coverage for energy/environment programs |
+| **County** | **HUD CDBG/HOME entitlement lists** (hudexchange.info), state housing agency recipient lists, Instrumentl county pages, National Association of Counties | DSIRE is weak for county programs — lead with HUD lists |
+| **Municipality** | **League of Cities/Towns** (state chapter), regional water association directories (AMWUA, etc.), city-wide grants index pages, Instrumentl city pages | DSIRE is weak for municipal programs — lead with association directories |
+| **Foundation** | Candid/GuideStar, GrantWatch, Instrumentl, state community foundation directories | Foundation databases are the strongest aggregators for this type |
+| **Other (COGs)** | HUD state CDBG contacts list, NARC member directory, state COG associations | No single aggregator covers COGs well — use HUD + direct search |
+
+### Key Aggregator Sources for County/Municipality (often missed)
+
+1. **HUD Exchange** (hudexchange.info) — the definitive source for who gets CDBG/HOME
+   money directly from HUD. Search: `"hudexchange" CDBG entitlement communities [State]`
+2. **State Housing Agency** grant recipient lists — most states publish who received
+   CDBG/HOME/ESG/HOPWA allocations. Search: `"[State] department of housing" grant recipients`
+3. **Regional water association directories** — in water-heavy states (AZ, NV, NM, CA, TX),
+   these list city water conservation offices with rebate programs. Example: AMWUA for
+   Arizona yielded 13 water conservation offices in one search.
+4. **League of Cities/Towns state chapters** — most states have one. They often maintain
+   grant/funding resource directories for their member cities.
+5. **Instrumentl** county/city landing pages — better than DSIRE for local government
+   programs. Search: `site:instrumentl.com "[County Name]" grants`
+
 ### How to Use Aggregator Data:
 - Cross-reference: if an entity appears in DSIRE but NOT in your PUC/EIA lists,
   investigate — it might be a co-op, tribal utility, or non-traditional funding source
+- For County/Municipality: **start with HUD entitlement lists and association directories**,
+  then cross-reference with DSIRE/Instrumentl. Do NOT start with DSIRE alone — you'll
+  miss the majority of local government funders.
 - Aggregators are especially valuable for non-utility funder types (foundations, state
   agencies) where there's no equivalent of the EIA database
 

--- a/.claude/skills/source-registry/SKILL.md
+++ b/.claude/skills/source-registry/SKILL.md
@@ -2,28 +2,43 @@
 name: source-registry
 description: >
   Phase 1 of the manual funding pipeline. Discovers funding entities
-  (utilities, state agencies, foundations, counties) via multi-strategy
-  web search, registers them in funding_sources, and discovers their
-  program catalog URLs in source_program_urls. Designed to be run by
-  Agent Team teammates or standalone via the Task tool.
+  (utilities, state agencies, foundations, counties, COGs) via multi-strategy
+  web search and PROPOSES them to the orchestrator for validation and
+  registration. Teammates DO NOT write to the database — the orchestrator
+  is the single writer. Designed to be run by Agent Team teammates.
 ---
 
 # Source Registry — Phase 1
 
 ## 1. Mission
 
-Find and register every funding entity for a given state and funder type.
-A missed source means all its programs and opportunities are invisible to
-our sales team — thoroughness is non-negotiable.
+Find every funding entity for a given state and funder type. A missed source
+means all its programs and opportunities are invisible to our sales team —
+thoroughness is non-negotiable.
 
-**Inputs** (provided by the orchestrator or user):
+**Inputs** (provided by the orchestrator):
 - `state_code` — two-letter abbreviation (e.g., `AZ`, `CA`). NULL for federal/national.
-- `type` — one of: `Utility`, `State`, `Federal`, `Foundation`, `County`, `Municipality`, `Other`
+- `type` — the SINGLE type you are searching for (e.g., `County`). Only propose
+  entities of this type. If you find entities that belong to a different type,
+  note them as "out-of-scope" in your report — do NOT propose them as your type.
+- `batch_id` — for audit logging
 
 **Outputs**:
-- Registered entities in `funding_sources`
-- Program catalog URLs in `source_program_urls`
-- Summary report: X new sources, Y enriched, Z catalog URLs found
+- **Proposed entity list** sent to orchestrator via SendMessage (NOT database writes)
+- Each proposal includes: name, website, type, description, catalog URLs, confidence, name_source
+- Summary report: X entities proposed, Y out-of-scope flagged
+
+## ⚠️ CRITICAL: DO NOT WRITE TO THE DATABASE
+
+You are a **proposer**, not a writer. Your job is to search, verify, and propose.
+The orchestrator validates (dedup, type check, name verification) and performs
+all INSERTs. This ensures zero duplicates and zero bad data in production.
+
+- **DO NOT** run INSERT statements against `funding_sources` or `source_program_urls`
+- **DO NOT** run UPDATE statements on existing rows
+- **DO** use `mcp__postgres__query` for READ-ONLY dedup checks (to avoid proposing
+  entities that already exist)
+- **DO** send your proposals to the team lead via SendMessage
 
 ---
 
@@ -154,11 +169,12 @@ Never stop searching because you hit a "target number."
 
 ---
 
-## 3. Step 2 — Deduplication and Registration
+## 3. Step 2 — Deduplication and Proposal
 
-For each entity from Step 1, check against existing `funding_sources` before writing.
+For each entity from Step 1, check against existing `funding_sources` before proposing.
+This pre-check avoids wasting the orchestrator's time on entities that already exist.
 
-### Dedup Query
+### Pre-Proposal Dedup Query (READ-ONLY)
 
 ```sql
 -- Run via mcp__postgres__query (raw SQL, no bind variables)
@@ -169,7 +185,8 @@ WHERE (
   OR name ILIKE '%APS%'
   OR website ILIKE '%aps.com%'
 )
-AND (state_code = 'AZ' OR state_code IS NULL);
+AND (state_code = 'AZ' OR state_code IS NULL)
+AND name NOT LIKE '[DEPRECATED-%';
 ```
 
 Substitute the actual entity name, abbreviation, and domain for each lookup.
@@ -179,27 +196,71 @@ Use `mcp__postgres__query` for this read (raw SQL strings, not psql bind syntax)
 
 | Scenario | Action |
 |----------|--------|
-| **No match found** | INSERT new source |
-| **Match found, has NULL fields** | UPDATE to enrich (fill NULL columns only) |
+| **No match found** | PROPOSE to orchestrator as new entity |
+| **Match found, has NULL fields** | PROPOSE as enrichment (note which fields to fill) |
 | **Match found, all fields populated** | SKIP — log as "already exists" |
 
-### INSERT Template
+### Proposal Format (sent via SendMessage to team-lead)
 
-```sql
--- Run via: psql "$PROD_CLAUDE_URL" -c "..."
-INSERT INTO funding_sources (name, website, type, sectors, state_code, pipeline, description)
-VALUES (
-  'Arizona Public Service Company',
-  'https://www.aps.com',
-  'Utility',
-  ARRAY['Energy', 'Sustainability']::TEXT[],
-  'AZ',
-  'manual',
-  'Known as APS. Largest electric utility in Arizona. Serves ~1.3M customers in central Arizona.'
-);
+For each proposed entity, include ALL of the following fields:
+
+```
+PROPOSED ENTITY:
+  name: "Arizona Public Service Company"
+  website: "https://www.aps.com"
+  type: Utility
+  state_code: AZ
+  sectors: [Energy, Sustainability]
+  description: "Known as APS. Largest electric utility in Arizona. Serves ~1.3M customers."
+  confidence: HIGH
+  name_source: "from website footer" (or "from About Us page", "from breadcrumb", "from search result only")
+  catalog_urls:
+    - https://www.aps.com/en/Residential/Save-Money-and-Energy/Rebates-and-Incentives
+    - https://www.aps.com/en/Business/Save-Money-and-Energy
+  dedup_check: "No match found in funding_sources for APS / aps.com / AZ"
 ```
 
-Adjust the ARRAY size to match actual sectors — can be 1 to 10+ values.
+**Name source field**: This tells the orchestrator whether to spot-check the name.
+- "from website footer" / "from About Us page" / "from breadcrumb" = verified, no spot-check needed
+- "from search result only" = orchestrator will verify via WebFetch before INSERT
+
+### DO NOT INSERT — the orchestrator handles all writes
+
+## 4. Step 3 — Catalog URL Validation
+
+Before including a catalog URL in your proposal, **verify it actually contains
+funding program content.** Do NOT propose URLs you haven't checked.
+
+### Validation Steps
+
+For each candidate catalog URL:
+1. Fetch the page (use the Content Retrieval Standard from program-discovery SKILL.md
+   Section 0a — WebFetch first, then curl-with-headers, then Playwright if needed)
+2. Check the page content for funding-program indicators:
+   - Look for: "Apply", "Grant Application", "Funding Opportunity", "RFP", "NOFA",
+     "Rebate", "Incentive", "Program Guidelines", specific dollar amounts
+   - Look for links to individual program pages (not just department navigation)
+3. Classify the URL:
+
+| What You See | Action |
+|---|---|
+| Page lists programs with "Apply" links or dollar amounts | **INCLUDE** — this is a real catalog URL |
+| Page is a department homepage with navigation links but no programs | **GO DEEPER** — follow the most promising link one level and check that page instead |
+| Page is a generic info page with no program content | **EXCLUDE** — do not propose this URL |
+| Page returns 404 or redirects to a generic landing page | **EXCLUDE** — dead URL |
+| Page is on a different domain or department than expected | **FLAG** — note the misattribution in your report |
+
+4. Include only validated catalog URLs in your proposal. Note any excluded URLs
+   and why in your report.
+
+### Why This Matters
+
+Bad catalog URLs waste Phase 2 scout time. A scout assigned a navigation hub or
+dead URL will crawl it, find nothing, and have to fall back to web search — losing
+10-20 minutes. Validating upfront takes ~5 seconds per URL and prevents junk data
+in `source_program_urls`.
+
+---
 
 ### UPDATE Template (enrich existing source)
 

--- a/.claude/skills/storage/SKILL.md
+++ b/.claude/skills/storage/SKILL.md
@@ -133,6 +133,10 @@ These fields mark the record as coming from the manual pipeline:
 | `api_opportunity_id` | `'manual'` | Literal string, identifies CC pipeline |
 | `program_id` | `staging.program_id` | FK to funding_programs (from Phase 3) |
 | `promotion_status` | `'pending_review'` | Hidden from dashboard until admin promotes |
+| `application_window_type` | From `extraction_data.applicationWindowType` or staging | `dated`, `rolling`, or `cycle_based` |
+| `funding_status` | From `extraction_data.fundingStatus` or staging | `verified_active`, `presumed_active`, `limited_funding`, `oversubscribed`, `exhausted` |
+| `funding_note` | From `extraction_data.fundingNote` or staging | Max 150 chars — evidence for funding status |
+| `funding_verified_at` | `NOW()` | Timestamp of when funding status was assessed |
 
 ---
 
@@ -237,6 +241,7 @@ INSERT INTO funding_opportunities (
   relevance_reasoning, relevance_score, scoring,
   agency_name, funding_source_id,
   api_source_id, api_opportunity_id, program_id, promotion_status,
+  application_window_type, funding_status, funding_note, funding_verified_at,
   created_at, updated_at
 ) VALUES (
   $STOR$<title>$STOR$,
@@ -277,6 +282,10 @@ INSERT INTO funding_opportunities (
   NULL,                    -- api_source_id (not from API)
   'manual',                -- api_opportunity_id
   '<program_id>'::uuid,    -- from staging
+  '<application_window_type>'::application_window_type,  -- dated/rolling/cycle_based
+  '<funding_status>'::funding_status_type,                -- verified_active/presumed_active/limited_funding/oversubscribed/exhausted
+  $STOR$<funding_note>$STOR$,                             -- max 150 chars evidence
+  NOW(),                   -- funding_verified_at
   'pending_review',        -- hidden until admin promotes
   NOW(),
   NOW()

--- a/supabase/migrations/20260414013149_add_funding_status_fields.sql
+++ b/supabase/migrations/20260414013149_add_funding_status_fields.sql
@@ -1,0 +1,56 @@
+-- Migration: Add funding status fields to funding_opportunities
+-- Purpose: Distinguish rolling vs dated programs, track funding availability,
+--          and give the pipeline explicit signals about program health.
+--
+-- Fields added:
+--   application_window_type: How the program accepts applications (dated/rolling/cycle_based)
+--   funding_status: Current funding availability assessment
+--   funding_note: Short evidence-based explanation (max 150 chars)
+--   funding_verified_at: When funding status was last verified by a pipeline agent
+
+-- Create the application_window_type enum
+DO $$ BEGIN
+  CREATE TYPE application_window_type AS ENUM ('dated', 'rolling', 'cycle_based');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Create the funding_status enum
+DO $$ BEGIN
+  CREATE TYPE funding_status_type AS ENUM (
+    'verified_active',    -- Explicit evidence of current acceptance (Apply Now, live portal)
+    'presumed_active',    -- Looks normal, no red flags, but no explicit confirmation
+    'limited_funding',    -- Known finite pool that could exhaust (first-come-first-served)
+    'oversubscribed',     -- Demand signals: waitlists, paused, limited availability
+    'exhausted'           -- Definitively confirmed: all funds awarded, program closed
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Add columns to funding_opportunities
+ALTER TABLE funding_opportunities
+  ADD COLUMN IF NOT EXISTS application_window_type application_window_type,
+  ADD COLUMN IF NOT EXISTS funding_status funding_status_type DEFAULT 'presumed_active',
+  ADD COLUMN IF NOT EXISTS funding_note VARCHAR(150),
+  ADD COLUMN IF NOT EXISTS funding_verified_at TIMESTAMPTZ;
+
+-- Add comment documentation
+COMMENT ON COLUMN funding_opportunities.application_window_type IS
+  'How this program accepts applications: dated (specific open/close dates), rolling (perpetual, no window), cycle_based (recurring cycles like annual CDBG)';
+
+COMMENT ON COLUMN funding_opportunities.funding_status IS
+  'Current funding availability: verified_active (confirmed accepting), presumed_active (no red flags), limited_funding (finite pool), oversubscribed (demand signals), exhausted (definitively closed)';
+
+COMMENT ON COLUMN funding_opportunities.funding_note IS
+  'Short evidence-based explanation for funding_status assessment, max 150 chars. Example: "Page shows Apply Now with FY2026 dates as of 4/13/2026"';
+
+COMMENT ON COLUMN funding_opportunities.funding_verified_at IS
+  'When the funding_status was last verified by a pipeline Phase 3 checker agent';
+
+-- Also add to the staging table so it flows through the pipeline
+ALTER TABLE manual_funding_opportunities_staging
+  ADD COLUMN IF NOT EXISTS application_window_type application_window_type,
+  ADD COLUMN IF NOT EXISTS funding_status funding_status_type DEFAULT 'presumed_active',
+  ADD COLUMN IF NOT EXISTS funding_note VARCHAR(150),
+  ADD COLUMN IF NOT EXISTS funding_verified_at TIMESTAMPTZ;


### PR DESCRIPTION
## Summary
- Switch 5 pipeline agents (extraction, opportunity-discovery, program-discovery, source-registry, storage) from Opus to Sonnet 4.6
- Keep analysis-agent on Opus for quality-critical scoring and content generation
- ~5x cost reduction on parallelized discovery and processing phases with faster execution (~2-3x)

## Test plan
- [ ] Run a pipeline discovery phase and verify agents spawn on Sonnet
- [ ] Verify analysis-agent still runs on Opus
- [ ] Spot-check output quality from Sonnet-powered agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)