### PR TITLE
Improve manual pipeline from CA State post-mortem

### DIFF
--- a/.claude/skills/opportunity-discovery/SKILL.md
+++ b/.claude/skills/opportunity-discovery/SKILL.md
@@ -96,6 +96,52 @@ Flag as "Requires login, could not crawl" — skip entirely.
 
 ---
 
+## 0b. UUID Copy-Fidelity Rule (IRON CLAD)
+
+When echoing UUIDs (`program_id`, `source_id`, batch IDs) into your findings
+report, SendMessage payload, or DB query, you MUST copy them VERBATIM from
+your input. **NEVER retype, abbreviate, reconstruct, or echo a UUID from
+memory.**
+
+**Why this rule exists**: LLMs reliably hallucinate UUIDs — typically keeping
+the first 8 characters (the distinctive "fingerprint") but inventing the tail.
+Example observed in production:
+- Real: `1b90e8d2-291d-4a50-ae02-b21db304d48a`
+- Hallucinated: `1b90e8d2-5c3a-4de0-b5c5-3a5e0c4b0d1a`
+
+In a prior run, Phase 3 Checkers 4 and 5 caused 9 findings to be dropped
+because they either hallucinated UUID tails or wrote semantic placeholders
+like `calfire-source-id`. The orchestrator now validates every UUID in your
+report, but recovery isn't guaranteed — if it can't match your finding to a
+real record, the finding is skipped entirely.
+
+**Rules**:
+
+1. **Copy, don't transcribe.** Your input programs.json contains the UUIDs
+   you need. When writing findings, copy-paste each `program_id` and
+   `source_id` exactly as they appear in your input. Do NOT retype.
+2. **Never invent placeholder UUIDs.** Strings like `calfire-source-id`,
+   `csfa-source-id`, or `tbd-uuid` are INVALID. If you don't have a UUID for
+   a field (for example, you discovered a program that wasn't in your input
+   and don't have its ID), emit `null` and note why. Provide the program's
+   **exact name** so the orchestrator can resolve it.
+3. **Need a UUID you weren't given?** Query the DB first:
+   ```sql
+   SELECT id, source_id FROM funding_programs
+   WHERE name = 'exact program name'
+     AND source_id IN (SELECT id FROM funding_sources WHERE name = 'exact source name');
+   ```
+   Use the returned value verbatim.
+4. **Your `findings` array must be UUID-faithful.** The orchestrator uses
+   the `program_id` in each finding as the PRIMARY KEY to resolve the
+   staging record. Every mangled UUID is a lost staging record.
+5. **SendMessage payloads follow the same rule.** If you're reporting a
+   finding via SendMessage, the UUID in the message body must have come
+   from a trusted source (your input JSON, a DB query result), not from
+   memory.
+
+---
+
 ## 1. Mission
 
 Check whether programs are currently accepting applications or will be soon.

--- a/.claude/skills/pipeline-orchestrator/SKILL.md
+++ b/.claude/skills/pipeline-orchestrator/SKILL.md
@@ -681,10 +681,75 @@ Extractors write source_id as the FK on `funding_programs`.
 
 After all scout batches complete:
 1. Merge program lists from all batches
-2. Dedup by URL (exact match) and by name+source (fuzzy match)
-3. Count total unique programs
-4. Plan extractor assignments: ~10 programs per extractor
-5. Report to user: "Round 1 complete: X programs found across Y sources. Starting extraction."
+2. **Apply stale URL repairs to `source_program_urls`** (see below)
+3. Dedup programs by URL (exact match) and by name+source (fuzzy match)
+4. Count total unique programs
+5. Plan extractor assignments: ~10 programs per extractor
+6. Report to user: "Round 1 complete: X programs found across Y sources. Starting extraction. Stale URLs repaired: N."
+
+##### Stale URL Repair (Step 2)
+
+Each scout emits a `stale_urls` array in its output JSON (see program-discovery
+skill § 5 for the schema). Collect these across all scouts and apply repairs
+to `source_program_urls`:
+
+**Step A — Collect and dedup stale_urls reports**:
+```python
+import json
+stale_reports = []
+for n in range(NUM_SCOUTS):
+    d = json.load(open(f'/tmp/meridian-phase2/scout-{n}-results.json'))
+    stale_reports.extend(d.get('stale_urls', []))
+
+# Dedup by stale_url (multiple scouts may report the same stale URL)
+seen = {}
+for r in stale_reports:
+    key = r['stale_url']
+    if key not in seen or r.get('confidence') == 'high':
+        seen[key] = r  # prefer high-confidence over lower
+unique_reports = list(seen.values())
+```
+
+**Step B — Apply UUID validation** (per § 7.5). Every `source_id` in a stale
+report must validate against `funding_sources` or be dropped.
+
+**Step C — Validate the replacement URL** before applying:
+For each report with a `replacement_url`:
+1. Confirm the replacement URL is reachable (WebFetch or curl). If not, skip
+   the repair — don't overwrite a stale URL with a broken one.
+2. Confirm the replacement page is a catalog page for the SAME source (spot
+   check content mentions the source name or matching grant topics). This
+   prevents cross-source URL contamination.
+
+**Step D — Apply the UPDATE**:
+```sql
+UPDATE source_program_urls
+SET url = '<replacement_url>',
+    last_crawled_at = NOW()
+WHERE source_id = '<validated-source-uuid>'
+  AND url = '<stale_url>';
+```
+
+**Step E — Handle no-replacement cases** (`replacement_url IS NULL`):
+When a scout reports a stale URL but could not find a replacement, flag
+it for review rather than updating. Options:
+- Leave the row in place (next scout run may find a replacement)
+- If the source has OTHER catalog URLs that are working, the next scout
+  run will still function — the stale row just wastes one WebFetch per run
+- Log the flag in `claude_change_log` so a human can review and manually remove
+
+**Step F — Log to audit table**:
+```sql
+INSERT INTO claude_change_log
+  (table_name, operation, pipeline_phase, batch_id, record_count, change_reason)
+VALUES
+  ('source_program_urls', 'UPDATE', 'stale_url_repair', '<batch_id>', <N>,
+   'Repaired N stale catalog URLs based on scout discoveries');
+```
+
+**Step G — Report to user**:
+Include in the Round 1 summary: `Stale URLs repaired: N (M unrepairable — flagged).`
+For each repair, show before → after in the detailed report.
 
 #### Round 2 — Extractor Team (Extract + Store)
 
@@ -1042,6 +1107,113 @@ WHERE analysis_status = 'complete' AND storage_status = 'pending';
   After each agent completes, re-check count. If more pending, spawn another.
   Report: "Stored X records (Y new, Z updated). Coverage areas linked: N."
 - If count == 0: skip, report "No pending storage records"
+
+---
+
+## 7.5. Agent Output UUID Validation (REQUIRED)
+
+Every UUID that comes back from an agent — in a report, a JSON file, or a
+SendMessage payload — **MUST be validated against the database before it
+becomes part of any INSERT/UPDATE**. This is non-negotiable and applies to
+every phase that writes results from agent output (Phase 1 Source Registry,
+Phase 2 Round 1 scouts → Round 2 extractors, Phase 3 opportunity checkers).
+
+### Known Failure Mode
+
+LLM agents (including Sonnet-class models used in this pipeline) reliably
+hallucinate UUIDs when echoing them from input to output. Two patterns:
+
+1. **Tail invention**: agent keeps the first 8 characters of a real UUID
+   (the distinctive fingerprint it can "remember") and fabricates the
+   remaining 28 characters. Example observed in `run-20260414-ca-state-full`:
+   - Real: `50deced6-8b10-49ae-b8f8-de87faf29224`
+   - Hallucinated: `50deced6-4b8f-4c3d-9b8a-8d6f89ab4df1`
+2. **Semantic placeholders**: agent outputs strings like `calfire-source-id`,
+   `csfa-source-id`, or `tbd-uuid` when it doesn't have a concrete identifier.
+
+Both patterns caused data loss in the CA State run (5 programs in Phase 2,
+9 findings in Phase 3) until the orchestrator added post-hoc validation.
+Every future run MUST validate up front.
+
+### Validation Procedure
+
+Before any staging INSERT, program UPDATE, or FK-bearing write that uses an
+agent-supplied UUID, run this five-step gate:
+
+**Step 1 — Regex format check**:
+```python
+import re
+UUID_RE = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
+# Reject if no match — this catches placeholders like "calfire-source-id"
+```
+
+**Step 2 — DB existence check**:
+```sql
+-- Run via mcp__postgres__query (or env-appropriate MCP)
+SELECT id FROM funding_sources WHERE id = '<uuid>';
+SELECT id FROM funding_programs WHERE id = '<uuid>';
+```
+If regex passes but no row returned → hallucinated UUID (correct format,
+wrong value). Proceed to recovery.
+
+**Step 3 — Name-based recovery**:
+If the agent supplied a name alongside the invalid UUID, look it up by
+normalized name:
+```sql
+SELECT id FROM funding_sources
+WHERE LOWER(REGEXP_REPLACE(name, '[^a-z0-9]', '', 'g'))
+    = LOWER(REGEXP_REPLACE('<agent-supplied-name>', '[^a-z0-9]', '', 'g'))
+  AND state_code = '<scope-state-code>'
+  AND type = '<scope-type>';
+```
+If exactly one match → use that UUID. If zero or multiple → proceed to Step 4.
+
+**Step 4 — Cross-reference via related IDs**:
+If the agent supplied a valid program_id but invalid source_id, derive source_id:
+```sql
+SELECT source_id FROM funding_programs WHERE id = '<valid-program-id>';
+```
+Equivalent patterns exist for opportunity → program, coverage → opportunity.
+
+**Step 5 — Fail loudly when unrecoverable**:
+If no UUID AND no usable name, DO NOT invent a fallback and DO NOT silently
+skip. Record the failure explicitly:
+```sql
+INSERT INTO claude_change_log
+  (table_name, operation, pipeline_phase, batch_id, record_count, change_reason)
+VALUES
+  ('<target_table>', 'validation_failed', '<phase>', '<batch_id>', 1,
+   'UUID validation failed: could not resolve agent-supplied identifier. Details: ...');
+```
+Then skip that record and surface the skip to the user in your phase report.
+
+### Practical Implementation
+
+The orchestrator should run validation once per batch of agent output, not
+per individual record, to avoid chatty DB queries. Typical pattern:
+
+1. Collect the full set of agent findings into one JSON file
+2. Pull the trusted UUID set for the current scope from the DB (one query)
+3. Build in-memory maps: `known_source_ids`, `known_program_ids`,
+   `program_to_source`, `name_to_id`
+4. Iterate findings, apply Steps 1-5 using the maps
+5. Write only validated records; log every recovery and every skip
+
+A reference implementation was used for `run-20260414-ca-state-full`:
+see `/tmp/meridian-phase3/retry_bad_uuids.py` (Name-based recovery map) and
+`/tmp/meridian-phase3/generate_sql.py` (Regex + DB existence + program_id →
+source_id cross-ref). Both use `claude_writer`-compatible SQL.
+
+### Reporting Requirements
+
+At end of phase, every validation pass MUST report:
+- Records with valid UUIDs (wrote directly): N
+- Records recovered via name lookup: N — list each with before/after
+- Records recovered via ID cross-reference: N
+- Records skipped due to unrecoverable UUID: N — list each with reason
+
+Silent drops are forbidden. If the orchestrator cannot reach 100% accounted-for,
+that is a pipeline failure and must be surfaced to the user.
 
 ---
 

--- a/.claude/skills/program-discovery/SKILL.md
+++ b/.claude/skills/program-discovery/SKILL.md
@@ -105,6 +105,56 @@ Always attempt Level 2 for these source types.
 
 ---
 
+## 0b. UUID Copy-Fidelity Rule (IRON CLAD)
+
+When echoing UUIDs (`source_id`, `program_id`, batch IDs, staging IDs) into
+scout output files, extractor SQL, SendMessage payloads, or DB queries, you
+MUST copy them VERBATIM from your input. **NEVER retype, abbreviate,
+reconstruct, or echo a UUID from memory.**
+
+**Why this rule exists**: LLMs reliably hallucinate UUIDs — typically
+keeping the first 8 characters (the distinctive "fingerprint") but inventing
+the tail. Example observed in production:
+- Real: `50deced6-8b10-49ae-b8f8-de87faf29224`
+- Hallucinated: `50deced6-4b8f-4c3d-9b8a-8d6f89ab4df1`
+
+This has caused data loss in prior runs (5 programs lost in Phase 2 Scout 0).
+The orchestrator now validates every UUID you emit, but every hallucination
+costs a recovery cycle and may result in your record being skipped if recovery
+fails.
+
+**Rules**:
+
+1. **Copy, don't transcribe.** When the UUID is in your input JSON or prompt,
+   treat it as an opaque token. Copy-paste the exact string into your output
+   — do NOT retype it character by character from memory. Use tool output
+   when emitting UUIDs into files:
+   ```bash
+   # Good: pipe UUID from input file directly
+   jq -c 'map({source_id, program_name, ...})' /tmp/input.json > /tmp/output.json
+   ```
+2. **Never invent placeholder UUIDs.** Strings like `calfire-source-id`,
+   `sjvapcd-source-id`, or `tbd-uuid` are INVALID and will be rejected by
+   the orchestrator. If you lack a UUID for a field, emit `null` and note
+   why. The orchestrator can resolve by name; it cannot resolve a fabricated
+   placeholder.
+3. **Need a UUID you weren't given?** Query the DB:
+   ```sql
+   SELECT id FROM funding_sources WHERE name = 'exact name here';
+   SELECT source_id FROM funding_programs WHERE id = '<known-program-uuid>';
+   ```
+   Use the returned value verbatim.
+4. **Scout output files**: when writing `scout-N-results.json`, every
+   `source_id` must match the exact string from `sources.json`. Extractors
+   depend on these IDs being correct — a mangled `source_id` means a foreign-
+   key violation and a lost program.
+5. **Extractor SQL**: in your INSERT/UPDATE statements, quote UUIDs from
+   trusted sources only (input prompt, DB query result). If you catch
+   yourself typing 36 hex characters by hand, stop — you are about to
+   hallucinate. Re-read the input and copy-paste.
+
+---
+
 ## 1. Mission
 
 Discover every funding program offered by registered sources. A missed program
@@ -217,6 +267,18 @@ of programs found.
 
 6. **Note PDF URLs** with `type: "pdf"` label — extractors handle PDFs later
 7. **Skip login-gated pages** — flag them instead: "Requires login, could not crawl"
+8. **Capture stale catalog URLs with replacements**: When an assigned catalog URL
+   returns 404, has moved, or points to a dead domain, AND you discover the
+   correct replacement via WebSearch or WebFetch redirect, record both URLs in
+   your `stale_urls` output (see Section 5). Do NOT write to `source_program_urls`
+   yourself — the orchestrator validates and updates. Examples of what to capture:
+   - Domain migration: `co.shasta.ca.us/air-quality` → `shastacounty.gov/air-quality`
+   - CivicPlus renumbering: `/grants/` (404) → `/1737/` (active)
+   - Slug change: `/programs-resources/` → `/community/grants.php`
+   - Dead domain: `tehamacountyair.com` → `tehcoapcd.net`
+   Include a `confidence` rating (`high` if you verified the replacement is a real
+   catalog page for the same source; `medium` if it's your best guess). If you
+   cannot find a replacement, record the stale URL with `replacement_url: null`.
 
 ### Searcher Variant (Supplementary Web Search)
 
@@ -268,6 +330,14 @@ After all scouts report, the team lead compares program lists. Scouts should fla
 > **any tier** (hot, strong, mild, OR weak). This confirms the program funds a
 > recognizable project. If you cannot map the program to ANY project type in the
 > taxonomy → **DO NOT INSERT**.
+>
+> **Residential housing exclusion**: If a program funds residential housing
+> construction — including affordable multifamily (HCD MHP, Homekey, LHTF,
+> PLHA, CalHFA Mixed-Income, etc.) — filter it out at Gate 3 even if the client
+> (city, PHA, county) is a Meridian client type. Residential is intentionally
+> excluded from the taxonomy because the construction scope is too small for
+> Meridian's book of business. Do NOT map these to `Student Housing` as a
+> workaround — that's dorms for higher ed, not residential housing.
 >
 > All three gates must pass. Log filtered programs with which gate(s) failed.
 
@@ -487,11 +557,39 @@ Programs:
    Type: Grant | Description: Brief summary
 ...
 
+Stale URLs:
+- stale_url: https://tehamacountyair.com/grants/
+  replacement_url: https://tehcoapcd.net/grants/
+  source_id: <uuid>
+  confidence: high
+  reason: domain dead; verified replacement via WebSearch + fetched
+- stale_url: https://old.example.ca.gov/grants/
+  replacement_url: null
+  source_id: <uuid>
+  confidence: n/a
+  reason: 404; could not find replacement
+
 Flags:
 - [any login-gated pages]
-- [any 404 or unreachable URLs]
 - [any low-confidence finds]
 ```
+
+**Stale URL schema** (when writing JSON output `scout-N-results.json`):
+```json
+"stale_urls": [
+  {
+    "stale_url": "<url that was 404/dead/moved>",
+    "replacement_url": "<verified working URL, or null>",
+    "source_id": "<uuid, copied verbatim from input>",
+    "confidence": "high | medium | low | n/a",
+    "reason": "brief explanation"
+  }
+]
+```
+
+Include this `stale_urls` array even if empty. The orchestrator consumes it
+during Phase 2 Round 1 post-processing to UPDATE `source_program_urls` entries
+(see pipeline-orchestrator skill § 6, Phase 2 validation + URL repair step).
 
 ### Extractor Report Format
 

--- a/.claude/skills/source-registry/SKILL.md
+++ b/.claude/skills/source-registry/SKILL.md
@@ -42,6 +42,42 @@ all INSERTs. This ensures zero duplicates and zero bad data in production.
 
 ---
 
+## ⚠️ CRITICAL: UUID Copy-Fidelity Rule
+
+When echoing UUIDs (source IDs, program IDs, batch IDs) into your proposals,
+SendMessage payloads, or DB lookups, you MUST copy them VERBATIM from your
+input. **NEVER retype, abbreviate, reconstruct, or echo a UUID from memory.**
+
+**Why this rule exists**: LLMs reliably hallucinate UUIDs — typically keeping
+the first 8 characters (the distinctive "fingerprint") but inventing the tail.
+Example observed in production:
+- Real: `50deced6-8b10-49ae-b8f8-de87faf29224`
+- Hallucinated: `50deced6-4b8f-4c3d-9b8a-8d6f89ab4df1`
+
+This has caused silent data loss in prior runs. The orchestrator now validates
+every UUID you emit, but every hallucination costs a recovery cycle and may
+result in your finding being skipped if recovery fails.
+
+**Rules**:
+
+1. **Copy, don't transcribe.** When the UUID is in your input prompt or in a
+   file you read, treat it as an opaque token. Copy-paste the exact string
+   into your output — do NOT retype character by character.
+2. **Never invent placeholder UUIDs.** Strings like `calfire-source-id`,
+   `csfa-source-id`, or `tbd-uuid` are INVALID. If you don't have a UUID for
+   a field, output `null` and note why in your report. The orchestrator can
+   resolve by name; it cannot resolve a fabricated placeholder.
+3. **Need a UUID you weren't given?** Query the DB:
+   ```sql
+   SELECT id FROM funding_sources WHERE name = 'exact name here';
+   ```
+   Use the returned value verbatim in your output.
+4. **SendMessage payloads follow the same rule.** Every UUID in a message
+   body must have been copied from a trusted source (input prompt, DB query
+   result, or prior tool output), not regenerated from memory.
+
+---
+
 ## 2. Step 1 — Multi-Strategy Web Search
 
 Run multiple complementary search strategies. When running as an Agent Team
@@ -172,33 +208,105 @@ Never stop searching because you hit a "target number."
 ## 3. Step 2 — Deduplication and Proposal
 
 For each entity from Step 1, check against existing `funding_sources` before proposing.
-This pre-check avoids wasting the orchestrator's time on entities that already exist.
+This pre-check avoids wasting the orchestrator's time on entities that already exist
+AND prevents creating new variants of agencies that are already in the DB under slightly
+different names.
 
-### Pre-Proposal Dedup Query (READ-ONLY)
+### Why This Matters
+
+The DB has historical duplicates from earlier API ingests where naming wasn't
+normalized — e.g., CalRecycle exists as 4 rows: `California Department of Resources
+Recycling and Recovery`, `California Department of Resources Recycling and Recovery
+(CalRecycle)`, `Department of Resources Recycling and Recovery`, `Department of
+Resources Recycling and Recovery (CalRecycle)`. Naive exact-name dedup misses these.
+Your job is to use the **strict fuzzy match below** so we don't add a 5th variant.
+
+### Pre-Proposal Dedup Query (READ-ONLY) — REQUIRED Pattern
+
+Run this normalized-name match FIRST. It strips parentheticals and non-alphanumeric
+characters so common variants collapse to the same canonical string.
 
 ```sql
+-- Primary check: normalized name match (catches parenthetical and punctuation variants)
 -- Run via mcp__postgres__query (raw SQL, no bind variables)
 SELECT id, name, website, type, state_code, sectors, pipeline
 FROM funding_sources
+WHERE LOWER(REGEXP_REPLACE(
+        REGEXP_REPLACE(name, '\s*\([^)]*\)', '', 'g'),   -- strip "(CalRecycle)" etc.
+        '[^a-z0-9]', '', 'g'                              -- strip punctuation/whitespace
+      ))
+    = LOWER(REGEXP_REPLACE(
+        REGEXP_REPLACE('California Department of Resources Recycling and Recovery', '\s*\([^)]*\)', '', 'g'),
+        '[^a-z0-9]', '', 'g'
+      ))
+  AND type = 'State'
+  AND (state_code = 'CA' OR state_code IS NULL)
+  AND name NOT LIKE '[DEPRECATED-%';
+```
+
+Substitute the actual entity name and `type`/`state_code` per lookup. This catches:
+- `Foo Bar Agency` ↔ `Foo Bar Agency (FBA)`
+- `Department of Foo` ↔ `Department  of  Foo` (whitespace variation)
+- `Smith-Jones LLC` ↔ `Smith Jones LLC` (punctuation variation)
+
+### Secondary Checks (Run if Primary Returns No Match)
+
+If the normalized match returns zero rows, also try these BEFORE proposing as new:
+
+```sql
+-- Check 2: website domain match (most reliable signal that two rows are the same entity)
+SELECT id, name, website FROM funding_sources
+WHERE website ILIKE '%calrecycle.ca.gov%'   -- substitute actual domain
+  AND type = 'State'
+  AND name NOT LIKE '[DEPRECATED-%';
+
+-- Check 3: substring match (catches "California" prefix variants like CDFW)
+-- "California Department of Fish and Wildlife" vs "Department of Fish and Wildlife"
+SELECT id, name FROM funding_sources
 WHERE (
-  name ILIKE '%Arizona Public Service%'
-  OR name ILIKE '%APS%'
-  OR website ILIKE '%aps.com%'
+  name ILIKE '%Department of Fish and Wildlife%'  -- core distinctive phrase
+  OR name ILIKE '%CDFW%'                          -- known abbreviation
 )
-AND (state_code = 'AZ' OR state_code IS NULL)
+AND type = 'State'
+AND (state_code = 'CA' OR state_code IS NULL)
 AND name NOT LIKE '[DEPRECATED-%';
 ```
 
-Substitute the actual entity name, abbreviation, and domain for each lookup.
-Use `mcp__postgres__query` for this read (raw SQL strings, not psql bind syntax).
+Use the **most distinctive phrase** in your substring search — the part of the name
+that uniquely identifies this agency. Strip generic prefixes like "California" or
+"Department of" from your search pattern; they appear in dozens of agencies.
 
 ### Decision Logic
 
 | Scenario | Action |
 |----------|--------|
-| **No match found** | PROPOSE to orchestrator as new entity |
+| **No match found AND ≥1 validated catalog URL** | PROPOSE to orchestrator as new entity |
+| **No match found AND zero validated catalog URLs** | **SKIP — log as "out-of-scope: no funding activity found"** (see § 4 hard gate) |
 | **Match found, has NULL fields** | PROPOSE as enrichment (note which fields to fill) |
 | **Match found, all fields populated** | SKIP — log as "already exists" |
+
+### Funding-Evidence Hard Gate (REQUIRED before proposing a NEW entity)
+
+An entity is only a funding "source" if it actually administers grants, rebates,
+incentives, loans, or other funding programs. Regulatory bodies, permitting
+agencies, policy commissions, enforcement agencies, training boards, and cultural
+commissions are NOT sources even when they appear on aggregator lists or in agency
+directories.
+
+**Rule**: Before proposing a NEW entity, you MUST have located at least ONE
+**validated catalog URL** (a page on the agency's own domain that lists
+funding programs, grants, RFPs, NOFAs, rebates, or incentives — see § 4 for the
+validation procedure). The homepage, About page, mission statement, or contact
+page do NOT count.
+
+If you cannot find such a URL after reasonable search:
+- Do NOT propose the entity
+- Log it in your report as: `OUT-OF-SCOPE: <name> — no funding activity found at <domain>`
+- Note the entity type if relevant (e.g., "regulatory commission", "permitting body")
+
+This gate applies to NEW entities only. Enrichments to existing sources (rows
+already in `funding_sources`) do not require fresh catalog URL discovery —
+existing sources keep their state regardless of whether you find new URLs.
 
 ### Proposal Format (sent via SendMessage to team-lead)
 
@@ -230,6 +338,13 @@ PROPOSED ENTITY:
 
 Before including a catalog URL in your proposal, **verify it actually contains
 funding program content.** Do NOT propose URLs you haven't checked.
+
+**This step is the funding-evidence hard gate from § 3.** If zero catalog URLs
+survive validation for a NEW entity, that entity is NOT a source and MUST NOT
+be proposed. Log it as out-of-scope and move on. Common offenders that fail this
+gate: regulatory bodies, permitting agencies, policy commissions, enforcement
+agencies, training boards, cultural commissions — they have websites but no
+grants/funding pages.
 
 ### Validation Steps
 


### PR DESCRIPTION
## Summary

Six skill-only changes from the CA State full-pipeline run (`run-20260414-ca-state-full`) that improve data integrity, source quality, and dedup robustness for the manual pipeline:

- **UUID copy-fidelity rule** on all four agent skills — prevents hallucinated UUIDs that caused 14 records to be dropped during the CA run
- **Orchestrator UUID validation** (pipeline-orchestrator § 7.5) — every agent-supplied UUID must validate against the DB before any write
- **Source-registry fuzzy dedup tightening** — normalized-name match catches `CalRecycle` ↔ `California Department of Resources Recycling and Recovery (CalRecycle)` variants (relates to #91)
- **Funding-Evidence Hard Gate** (source-registry § 3, § 4) — NEW entities must have a validated catalog URL with funding content before proposal; filters out regulatory bodies (relates to #92)
- **Residential housing exclusion note** (program-discovery Gate 3) — documents the intentional taxonomy exclusion
- **Stale catalog URL repair flow** (program-discovery + pipeline-orchestrator) — scouts report stale URLs with replacements; orchestrator validates and updates `source_program_urls`

Total: 4 skill files modified, +445 / -14 lines. No code or DB schema changes.

Relates to #91, #92.

## Test plan

This PR contains only skill (markdown documentation) changes. No code execution or test runs apply.

- [ ] Review the 4 skill diffs for clarity and consistency with existing skill voice
- [ ] Confirm UUID copy-fidelity rule appears in all 4 agent-side skills (orchestrator, source-registry, program-discovery, opportunity-discovery)
- [ ] Confirm the orchestrator's § 7.5 UUID validation section provides actionable SQL/Python examples
- [ ] Confirm the source-registry Funding-Evidence Hard Gate references back to § 4 catalog URL validation
- [ ] Confirm program-discovery Gate 3 residential exclusion text doesn't contradict any existing scope rules

The skills will get exercised by the next manual pipeline run; confidence comes from review of the documentation itself, not automated testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)