### PR TITLE
Pipeline skills: LLM dedup + program viability + ambiguous page tiebreaker

### DIFF
--- a/.claude/skills/opportunity-discovery/SKILL.md
+++ b/.claude/skills/opportunity-discovery/SKILL.md
@@ -465,6 +465,56 @@ or a one-line announcement.
 March 1, 2026"). Vague timeframes like "summer 2026" or "Q3" are NOT considered
 known dates — treat as "date not known" (Row 4).
 
+### Ambiguous Page Tiebreaker (Row 2 vs Row 6)
+
+Some pages do not fit cleanly into Open or Nothing — they have a program name and
+description but **no dates, no "Apply Now", no "rolling basis" language, and no
+"closed" language either**. The decision tree alone can send checker A to Row 2
+(stage as rolling) and checker B to Row 6 (skip), which is inconsistent.
+
+**Use this single test to break the tie: is there an application mechanism on the
+page?**
+
+An application mechanism is any concrete way a real applicant could act today:
+
+- A live application portal link (Formstack, ZoomGrants, eCivis, Submittable, etc.)
+- A downloadable application PDF, RFP, NOFO, RFA, or fillable form
+- An "Apply" / "How to Apply" / "Submit" section with instructions
+- An application contact email or phone number explicitly for applicants
+- A program coordinator listed with contact info inviting inquiries
+
+**Decision:**
+
+| Application mechanism present? | Action | Row |
+|---|---|---|
+| **Yes** — applicant can act | INSERT staging, `window_type=rolling` | Row 2 |
+| **No** — page is informational only | SKIP, recheck in 30 days | Row 6 |
+
+**When you go Row 2 on an ambiguous page, the `funding_note` MUST carry the
+evidence trail.** This is the case where the agent is making a judgment call,
+so the note is what lets a downstream reviewer audit it. Examples:
+
+- ✅ "Program description page, contact email provided for applications, no closure
+  language found — presumed active."
+- ✅ "Downloadable RFA on page, no current-year date but document looks current —
+  presumed active pending verification."
+- ❌ "Open program." (no evidence — fails the audit trail)
+- ❌ "Looks active." (no evidence)
+
+**Tie the `funding_status` call back to §3f signals.** The ambiguous page almost
+always lands on `presumed_active` (the default-when-nothing-concerning bucket),
+but check first whether any §3f signals are actually present:
+
+- Funding pool dollar amount mentioned → `limited_funding`
+- "Limited availability" / "subject to funding" language → `limited_funding`
+- "Waitlist" / "currently paused" language → `oversubscribed`
+- Any "all funds awarded" / "program closed" language → `exhausted` (and don't
+  stage — see Row 6 / Step 3 exhausted logic in pipeline-orchestrator)
+- None of the above → `presumed_active`
+
+The funding_status is the agent's best read of program health; the funding_note
+is the evidence. Both are required on every report regardless of which row.
+
 ### Re-Check Scenarios
 
 When `next_check_at` arrives for a Row 3 program (upcoming with date):

--- a/.claude/skills/program-discovery/SKILL.md
+++ b/.claude/skills/program-discovery/SKILL.md
@@ -181,18 +181,32 @@ spawns extractors with deduplicated program assignments.
 
 ### Program Granularity Rule
 
-When a single program page lists multiple sub-rebates or sub-grants under one
-umbrella (e.g., a "Home Weatherization" page with 7 different rebate types at
-different dollar amounts), register as **ONE program record**. Capture the
-sub-types in the `description` and `eligible_project_types` array.
+A program is something a real applicant can independently apply to in its own
+right — not a category, theme, or sub-tier within something larger that they
+actually apply to.
 
-Only split into separate records when sub-programs have:
-- Independent application processes (different forms, different portals)
-- Different eligibility requirements (different applicant types)
-- Different funding sources (one is CDBG, another is General Fund)
+Before adding any candidate to your report, do this thought experiment:
+**If a real applicant walked up and said "I want to apply to X," what would
+they actually do?** If they'd submit a unique application that exists for X
+alone, you've found a program. If they'd file an application to a parent
+program and just select X as a category — then X is a sub-category, not a
+program. Roll it up.
 
-If they share one application, one eligibility set, and one funding source,
-they are one program with multiple components.
+The trap to avoid: agency websites often have "services" or "what we fund"
+sections that present every sub-category as if it were a separate program —
+its own page, its own description, its own funding write-up. They look like
+programs. They're not. They're marketing presentations of categories within
+one program.
+
+Use whatever signals help you tell the difference — URL structure, page
+framing, whether the application path is unique or shared with siblings,
+whether it has its own filing rounds / program manager / funding pool, how
+the agency talks about it. No checklist. Just answer the thought experiment
+honestly.
+
+**When in doubt, prefer fewer programs over more.** Register the parent
+once; capture sub-categories as metadata in `description` and
+`eligible_project_types`.
 
 ### Cross-Source Attribution Rule
 
@@ -253,7 +267,10 @@ of programs found.
    - Infrastructure: building upgrades, weatherization
    - Housing: home improvement, low-income assistance
    - Transportation: EV rebates, fleet conversion programs
-5. **For each program found, capture**:
+5. **For each candidate program, apply the Program Granularity Rule (§1) before
+   including it in your report.** Roll up sub-categories to their parent program
+   rather than reporting them separately.
+6. **For each program found, capture**:
 
 | Field | Required | Notes |
 |-------|----------|-------|
@@ -265,9 +282,9 @@ of programs found.
 | `brief_description` | Yes | 1-2 sentence summary |
 | `funding_type` | If identifiable | Grant, Incentive, Loan, Tax Credit, etc. |
 
-6. **Note PDF URLs** with `type: "pdf"` label — extractors handle PDFs later
-7. **Skip login-gated pages** — flag them instead: "Requires login, could not crawl"
-8. **Capture stale catalog URLs with replacements**: When an assigned catalog URL
+7. **Note PDF URLs** with `type: "pdf"` label — extractors handle PDFs later
+8. **Skip login-gated pages** — flag them instead: "Requires login, could not crawl"
+9. **Capture stale catalog URLs with replacements**: When an assigned catalog URL
    returns 404, has moved, or points to a dead domain, AND you discover the
    correct replacement via WebSearch or WebFetch redirect, record both URLs in
    your `stale_urls` output (see Section 5). Do NOT write to `source_program_urls`


### PR DESCRIPTION
## Summary

Three skill improvements to the manual funding pipeline, all from work during the CA State / OPSC post-mortem and the subsequent CA program viability cleanup pass.

### 1. LLM-based Phase 3 pre-flight dedup (orchestrator)

The SQL-only NOT EXISTS dedup check caught only 1 of ~120 cross-pipeline duplicates in the CA run. Three SQL-level problems made exact/substring matching unreliable:

- API-ingested opportunities have `program_id IS NULL` (#93), so the FK match never fires against them
- Title fuzzy match via ILIKE substring breaks on naming variance (e.g. "Modernization Funding for Schools" vs "SFP Modernization Proposition 2")
- Source attribution legitimately differs across pipelines for the same program (SOMAH under CPUC manual vs PG&E API)

Replaced the weak fuzzy fallback with explicit two-step LLM judgment in Phase 3 pre-flight:

- **Step 0.5a** — `pg_trgm` candidate query (title similarity > 0.2 OR same source_id OR same URL domain — independent signals OR'd together)
- **Step 0.5b** — Send (program + up to 20 candidates) to Sonnet for the precise "same underlying program?" judgment
- **Step 0.5c** — Skip on medium/high confidence duplicate; proceed on low confidence (Phase 6 UPSERT remains backstop)
- **Step 0.5d/e** — Update scheduling for skipped programs, log to claude_change_log, report skip and near-miss counts

Sanity-tested similarity() against real Tier-1 duplicates from the CA run: trigram catches 7 of 8; the eighth (SOMAH, short acronym) is caught by the URL-domain bonus signal.

### 2. Program Granularity Rule rewrite (program-discovery §1)

Previous rule was a checklist that only fired when sub-programs sat on ONE page. In practice, agencies have services-list pages where each sub-category gets its own URL/page/description, and agents were treating each as a separate program. Result: OPSC registered Seismic, Modernization, Facility Hardship, etc. as 9 separate programs when applicants actually submit Form SAB 50-04 to one School Facility Program and select a category. The CA cleanup soft-deleted 118 such fragmented/non-viable programs (~32% of 373).

Replaced with concept-based framing built around one thought experiment: *"If a real applicant walked up and said 'I want to apply to X', what would they actually do?"* Names the failure mode (services-list pages that present categories as programs), grants the agent license to use any signal (URL structure, page framing, application path, operational independence), and sets a default lean ("when in doubt, prefer fewer programs").

Scout Step 5 added as a forward-reference to apply the rule before reporting any candidate.

### 3. Ambiguous Page Tiebreaker (opportunity-discovery §4)

The Row 2 vs Row 6 decision (stage as rolling vs skip as nothing-found) had no rule for pages that fit neither cleanly — no dates, no Apply Now, no rolling language, no closure language. Checkers were making inconsistent calls.

Added a one-paragraph tiebreaker: use "is there an application mechanism on the page?" as the test. Five concrete signals (portal link, downloadable application PDF, How-to-Apply section, application contact, program coordinator inviting inquiries). Plus a funding_note evidence requirement for the judgment call, with passing/failing examples. Ties funding_status back to §3f signal list so the status bucket isn't a free judgment.

## Files Changed

- `.claude/skills/pipeline-orchestrator/SKILL.md` — +173 / -4 (LLM dedup section)
- `.claude/skills/program-discovery/SKILL.md` — +49 / -16 (Granularity Rule rewrite + Scout Step 5)
- `.claude/skills/opportunity-discovery/SKILL.md` — +50 / -0 (Ambiguous Page Tiebreaker)

## Test Plan

- [ ] Skill files are valid markdown, render correctly
- [ ] No code or schema changes — skill-only PR
- [ ] Next manual pipeline run on a fresh state (e.g. Arizona, which is the planned next state) exercises:
  - Granularity Rule should reject sub-category registrations during Stage 2
  - Ambiguous Page Tiebreaker should drive consistent Row 2 vs Row 6 decisions
  - LLM dedup pre-flight in Phase 3 should report skip count and near-miss count

## Related

Validated in production via the CA program viability cleanup (118 programs soft-deleted across 7 passes; 39 linked opportunities rejected). The cleanup execution surfaced the Granularity Rule and Ambiguous Page Tiebreaker gaps that this PR fixes for future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)